### PR TITLE
Bootstrap Linode Image Lab M1 foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+This repository uses the shared `ai-workflow-playbook` as the canonical source
+for general workflow rules. This file is the thin repo-local execution layer.
+Repo-local rules take precedence only for repo-specific behavior.
+
+## Repo Scope
+
+- This repo contains a public-safe Linode Image Lab scaffold.
+- M1 behavior is limited to dry-run planning, manifest modeling, tag contracts,
+  cleanup selection logic, docs, and tests.
+- Do not add real Linode mutation behavior until a later milestone explicitly
+  asks for it.
+
+## Public-Safe Boundary
+
+- Treat every file as public.
+- Do not commit secret values, private identifiers, non-public URLs, or
+  workplace metadata.
+- `LINODE_TOKEN` may appear only as an environment variable name.
+- Fixtures must be sanitized and live under `tests/fixtures/sanitized/`.
+
+## Validation
+
+- Use `make check` as the canonical validation entrypoint.
+- Use `make security-check` for the public-safety scan.
+- Keep validation implemented through the Makefile rather than direct tool
+  invocation in normal workflow.
+
+## Branches and PRs
+
+- Branch from current `origin/main`.
+- Use focused branch names such as `codex/bootstrap-m1-foundation`.
+- Open PRs against `main`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+PYTHON ?= python3
+export PYTHONPATH := src
+
+.PHONY: check test security-check
+
+check: security-check test
+
+test:
+	$(PYTHON) -m unittest discover -s tests/unit -p 'test_*.py'
+
+security-check:
+	$(PYTHON) -m linode_image_lab.validation .

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# linode-image-lab
-Minimal Linode image freeze/thaw lab scaffold.
+# Linode Image Lab
+
+Linode Image Lab is a small Python scaffold for modeling image freeze/thaw
+workflows before any real cloud mutation behavior exists.
+
+M1 is intentionally conservative:
+
+- `plan` emits a dry-run, sanitized manifest-like preview.
+- `freeze`, `thaw`, and `freeze-thaw` are explicit placeholders.
+- `cleanup` is first-class and independently runnable.
+- Manifest schema, rediscoverable tags, and cleanup selection are the foundation.
+
+## Quick Start
+
+```sh
+make check
+PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east --run-id demo-run
+```
+
+`LINODE_TOKEN` is reserved for later Linode API work. M1 does not read or use
+the value.
+
+## Required Tags
+
+Every modeled resource uses rediscoverable tags:
+
+- `project=linode-image-lab`
+- `run_id=<unique-id>`
+- `mode=<freeze|thaw|freeze-thaw>`
+- `component=<builder|thaw>`
+- `ttl=<timestamp>`
+
+## Commands
+
+```sh
+PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east,us-west
+PYTHONPATH=src python3 -m linode_image_lab.cli freeze --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli thaw --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli freeze-thaw --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
+```
+
+The placeholder commands return structured JSON and do not mutate Linode
+resources.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,27 @@
+# Compliance and Public Safety
+
+This repository is intended to be safe for public publication.
+
+## Allowed
+
+- Public product names needed to explain the project.
+- Environment variable names such as `LINODE_TOKEN`.
+- Sanitized fixtures under `tests/fixtures/sanitized/`.
+- Deterministic mock resource identifiers.
+
+## Not Allowed
+
+- Secret values.
+- Personal contact values.
+- Non-public service URLs.
+- Private account names or machine names.
+- Workplace metadata unrelated to this public project.
+
+## Review Checklist
+
+Before opening a PR:
+
+- run `make check`,
+- confirm fixtures are sanitized,
+- confirm commands remain dry-run or placeholder-only,
+- confirm docs describe behavior without private context.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,34 @@
+# Design
+
+Linode Image Lab M1 models the control-plane contract for a future image
+freeze/thaw workflow without implementing real Linode mutations.
+
+## Goals
+
+- Provide a minimal CLI with deterministic JSON output.
+- Create sanitized manifest previews for dry-run planning.
+- Define a stable tag contract for resource rediscovery.
+- Make cleanup selection testable without cloud access.
+
+## Non-Goals
+
+- No real Linode API mutations.
+- No scheduler integration.
+- No deployment automation.
+- No GitHub Actions integration.
+
+## Components
+
+- `cli.py` owns command parsing and JSON output.
+- `manifest.py` owns manifest creation, tag generation, and serialization.
+- `regions.py` owns one-or-many region parsing.
+- `cleanup.py` owns tag-based cleanup candidate selection.
+- `redaction.py` owns recursive output sanitization.
+- `linode_api.py` is a placeholder boundary for a future client.
+
+## Manifest Foundation
+
+Manifests are plain JSON-compatible dictionaries. They include schema version,
+project, command, mode, regions, timestamps, dry-run status, tags, and planned
+actions. Future milestones can add fields while preserving the required tag
+contract.

--- a/docs/freeze-thaw.md
+++ b/docs/freeze-thaw.md
@@ -1,0 +1,32 @@
+# Freeze-Thaw Workflow
+
+M1 documents the intended workflow shape while keeping execution non-mutating.
+
+## Freeze
+
+The future freeze flow will build or identify image inputs, create a manifest,
+tag rediscoverable resources, and record enough state for cleanup. In M1, the
+command returns a placeholder manifest and performs no Linode action.
+
+## Thaw
+
+The future thaw flow will recreate runnable resources from a frozen image and
+manifest. In M1, the command returns a placeholder manifest and performs no
+Linode action.
+
+## Freeze-Thaw
+
+The future combined flow will freeze and then thaw in a single run. In M1, the
+command returns a placeholder manifest with `mode=freeze-thaw`.
+
+## Cleanup
+
+Cleanup is independently runnable. It selects resources by required tags and an
+expired `ttl` timestamp. A resource is not a cleanup candidate unless all
+required tags are present:
+
+- `project=linode-image-lab`
+- `run_id=<unique-id>`
+- `mode=<freeze|thaw|freeze-thaw>`
+- `component=<builder|thaw>`
+- `ttl=<timestamp>`

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,29 @@
+# Security
+
+M1 is designed to be public-safe and non-mutating.
+
+## Token Handling
+
+- `LINODE_TOKEN` may appear as an environment variable name.
+- Secret values must never be committed.
+- The CLI does not read token values in M1.
+- Redaction utilities sanitize sensitive keys and token-like text before output.
+
+## Public-Safety Scan
+
+`make security-check` scans repository text files for:
+
+- sensitive value assignments,
+- email-like values,
+- private network URLs,
+- restricted workplace metadata,
+- non-public fixture placement.
+
+The scan is intentionally small and local. It is a guardrail, not a full data
+loss prevention system.
+
+## Mutation Safety
+
+`plan` is dry-run only. `freeze`, `thaw`, and `freeze-thaw` return explicit
+placeholder responses. `cleanup` currently selects candidates from provided data
+structures and does not call Linode.

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,6 +17,7 @@ M1 is designed to be public-safe and non-mutating.
 - email-like values,
 - private network URLs,
 - restricted workplace metadata,
+- hidden Unicode bidirectional control characters,
 - non-public fixture placement.
 
 The scan is intentionally small and local. It is a guardrail, not a full data

--- a/examples/cloud-init/minimal.yaml
+++ b/examples/cloud-init/minimal.yaml
@@ -1,0 +1,4 @@
+#cloud-config
+package_update: false
+packages: []
+final_message: "linode-image-lab minimal cloud-init complete"

--- a/src/linode_image_lab/__init__.py
+++ b/src/linode_image_lab/__init__.py
@@ -1,0 +1,5 @@
+"""Linode Image Lab bootstrap package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -1,0 +1,50 @@
+"""Cleanup selection logic for tagged resources."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from .manifest import PROJECT, REQUIRED_TAG_KEYS, VALID_COMPONENTS, VALID_MODES, tags_to_dict
+
+
+def parse_ttl(value: str) -> datetime | None:
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def resource_tags(resource: dict[str, Any]) -> dict[str, str]:
+    return tags_to_dict(resource.get("tags", []))
+
+
+def is_cleanup_candidate(resource: dict[str, Any], *, now: datetime | None = None) -> bool:
+    tags = resource_tags(resource)
+    if any(key not in tags for key in REQUIRED_TAG_KEYS):
+        return False
+    if tags["project"] != PROJECT:
+        return False
+    if tags["mode"] not in VALID_MODES:
+        return False
+    if tags["component"] not in VALID_COMPONENTS:
+        return False
+
+    ttl = parse_ttl(tags["ttl"])
+    if ttl is None:
+        return False
+
+    comparison_time = (now or datetime.now(UTC)).astimezone(UTC)
+    return ttl <= comparison_time
+
+
+def select_cleanup_candidates(
+    resources: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    return [resource for resource in resources if is_cleanup_candidate(resource, now=now)]

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -1,0 +1,116 @@
+"""Command line interface for Linode Image Lab."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+from .cleanup import select_cleanup_candidates
+from .freeze import freeze_plan
+from .manifest import create_manifest, serialize_manifest
+from .regions import parse_regions
+from .thaw import thaw_plan
+
+
+def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
+    parser.add_argument(
+        "--region",
+        action="append",
+        required=required,
+        help="Linode region id. May be repeated or comma-separated.",
+    )
+    parser.add_argument("--run-id", help="Optional run id for deterministic planning.")
+    parser.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="linode-image-lab")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="Emit a dry-run manifest preview.")
+    add_region_args(plan, required=True)
+    plan.add_argument(
+        "--mode",
+        choices=("freeze", "thaw", "freeze-thaw"),
+        default="freeze-thaw",
+        help="Workflow mode to model.",
+    )
+
+    freeze = subparsers.add_parser("freeze", help="Placeholder freeze command.")
+    add_region_args(freeze, required=True)
+
+    thaw = subparsers.add_parser("thaw", help="Placeholder thaw command.")
+    add_region_args(thaw, required=True)
+
+    freeze_thaw = subparsers.add_parser("freeze-thaw", help="Placeholder combined command.")
+    add_region_args(freeze_thaw, required=True)
+
+    cleanup = subparsers.add_parser("cleanup", help="Placeholder cleanup command.")
+    cleanup.add_argument("--run-id", help="Optional run id to include in the cleanup preview.")
+    cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
+
+    return parser
+
+
+def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    if args.command == "plan":
+        return create_manifest(
+            command="plan",
+            mode=args.mode,
+            regions=parse_regions(args.region),
+            run_id=args.run_id,
+            ttl=args.ttl,
+            dry_run=True,
+            status="planned",
+        )
+
+    if args.command == "freeze":
+        return freeze_plan(regions=parse_regions(args.region), run_id=args.run_id, ttl=args.ttl)
+
+    if args.command == "thaw":
+        return thaw_plan(regions=parse_regions(args.region), run_id=args.run_id, ttl=args.ttl)
+
+    if args.command == "freeze-thaw":
+        manifest = create_manifest(
+            command="freeze-thaw",
+            mode="freeze-thaw",
+            regions=parse_regions(args.region),
+            run_id=args.run_id,
+            ttl=args.ttl,
+            dry_run=True,
+            status="placeholder",
+        )
+        manifest["message"] = "freeze-thaw is a non-mutating placeholder in M1"
+        return manifest
+
+    if args.command == "cleanup":
+        manifest = create_manifest(
+            command="cleanup",
+            mode="freeze-thaw",
+            regions=[],
+            run_id=args.run_id,
+            ttl=args.ttl,
+            dry_run=True,
+            status="placeholder",
+        )
+        manifest["message"] = "cleanup is independently runnable and non-mutating in M1"
+        manifest["cleanup_candidates"] = select_cleanup_candidates([])
+        return manifest
+
+    raise ValueError(f"unsupported command: {args.command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        manifest = command_manifest(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+    sys.stdout.write(serialize_manifest(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/linode_image_lab/freeze.py
+++ b/src/linode_image_lab/freeze.py
@@ -1,0 +1,21 @@
+"""Freeze command placeholder."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .manifest import create_manifest
+
+
+def freeze_plan(*, regions: list[str], run_id: str | None = None, ttl: str | None = None) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="freeze",
+        mode="freeze",
+        regions=regions,
+        run_id=run_id,
+        ttl=ttl,
+        dry_run=True,
+        status="placeholder",
+    )
+    manifest["message"] = "freeze is a non-mutating placeholder in M1"
+    return manifest

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -1,0 +1,20 @@
+"""Placeholder Linode API boundary.
+
+M1 intentionally performs no Linode mutations. Future milestones can replace
+this boundary with a real client while keeping command modules small.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LinodeClient:
+    token_env_name: str = "LINODE_TOKEN"
+
+    def mutation_enabled(self) -> bool:
+        return False
+
+    def list_resources(self) -> list[dict[str, object]]:
+        return []

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -1,0 +1,129 @@
+"""Manifest and tag contract helpers."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+from .redaction import redact
+
+PROJECT = "linode-image-lab"
+SCHEMA_VERSION = 1
+VALID_MODES = {"freeze", "thaw", "freeze-thaw"}
+VALID_COMPONENTS = {"builder", "thaw"}
+REQUIRED_TAG_KEYS = ("project", "run_id", "mode", "component", "ttl")
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def format_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_ttl(now: datetime | None = None) -> str:
+    base = now or utc_now()
+    return format_timestamp(base + timedelta(hours=4))
+
+
+def validate_mode(mode: str) -> str:
+    if mode not in VALID_MODES:
+        choices = ", ".join(sorted(VALID_MODES))
+        raise ValueError(f"mode must be one of: {choices}")
+    return mode
+
+
+def validate_component(component: str) -> str:
+    if component not in VALID_COMPONENTS:
+        choices = ", ".join(sorted(VALID_COMPONENTS))
+        raise ValueError(f"component must be one of: {choices}")
+    return component
+
+
+def generate_tags(*, run_id: str, mode: str, component: str, ttl: str) -> list[str]:
+    """Generate rediscoverable tags for every modeled resource."""
+    validate_mode(mode)
+    validate_component(component)
+    return [
+        f"project={PROJECT}",
+        f"run_id={run_id}",
+        f"mode={mode}",
+        f"component={component}",
+        f"ttl={ttl}",
+    ]
+
+
+def tags_to_dict(tags: list[str] | dict[str, str]) -> dict[str, str]:
+    if isinstance(tags, dict):
+        return {str(key): str(value) for key, value in tags.items()}
+
+    parsed: dict[str, str] = {}
+    for tag in tags:
+        if "=" not in tag:
+            continue
+        key, value = tag.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+def component_for_mode(mode: str) -> str:
+    return "thaw" if mode == "thaw" else "builder"
+
+
+def create_manifest(
+    *,
+    command: str,
+    mode: str,
+    regions: list[str],
+    run_id: str | None = None,
+    ttl: str | None = None,
+    dry_run: bool = True,
+    status: str = "planned",
+) -> dict[str, Any]:
+    """Create a JSON-compatible manifest for a CLI command."""
+    validate_mode(mode)
+    if not regions and command != "cleanup":
+        raise ValueError("at least one region is required")
+
+    created_at = format_timestamp(utc_now())
+    manifest_run_id = run_id or f"run-{uuid4().hex[:12]}"
+    manifest_ttl = ttl or default_ttl()
+    component = component_for_mode(mode)
+    tags = generate_tags(
+        run_id=manifest_run_id,
+        mode=mode,
+        component=component,
+        ttl=manifest_ttl,
+    )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "project": PROJECT,
+        "command": command,
+        "mode": mode,
+        "run_id": manifest_run_id,
+        "regions": regions,
+        "created_at": created_at,
+        "ttl": manifest_ttl,
+        "dry_run": dry_run,
+        "status": status,
+        "tags": tags,
+        "planned_actions": [
+            {
+                "action": command,
+                "region": region,
+                "component": component,
+                "mutates": False,
+                "tags": tags,
+            }
+            for region in regions
+        ],
+    }
+
+
+def serialize_manifest(manifest: dict[str, Any]) -> str:
+    """Serialize a sanitized manifest with stable formatting."""
+    return json.dumps(redact(manifest), indent=2, sort_keys=True) + "\n"

--- a/src/linode_image_lab/redaction.py
+++ b/src/linode_image_lab/redaction.py
@@ -1,0 +1,50 @@
+"""Redaction helpers for public-safe CLI output."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+REDACTION = "[REDACTED]"
+SENSITIVE_KEY_RE = re.compile(r"(token|secret|password|api[_-]?key|credential)", re.I)
+TOKEN_TEXT_RE = re.compile(
+    r"(?i)\b(bearer\s+)[a-z0-9._~+/=-]{8,}|\b(token|secret|password)=([^\s]+)"
+)
+
+
+def is_sensitive_key(key: str) -> bool:
+    return bool(SENSITIVE_KEY_RE.search(key))
+
+
+def redact_text(value: str) -> str:
+    """Redact token-like text while preserving environment variable names."""
+    if value == "LINODE_TOKEN":
+        return value
+
+    def replace(match: re.Match[str]) -> str:
+        if match.group(1):
+            return f"{match.group(1)}{REDACTION}"
+        if match.group(2):
+            return f"{match.group(2)}={REDACTION}"
+        return REDACTION
+
+    return TOKEN_TEXT_RE.sub(replace, value)
+
+
+def redact(value: Any) -> Any:
+    """Recursively redact mappings and sequences."""
+    if isinstance(value, Mapping):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            redacted[key_text] = REDACTION if is_sensitive_key(key_text) else redact(item)
+        return redacted
+
+    if isinstance(value, str):
+        return redact_text(value)
+
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray)):
+        return [redact(item) for item in value]
+
+    return value

--- a/src/linode_image_lab/regions.py
+++ b/src/linode_image_lab/regions.py
@@ -1,0 +1,27 @@
+"""Region parsing helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def parse_regions(value: str | Iterable[str] | None) -> list[str]:
+    """Parse one or many region values into a stable, de-duplicated list."""
+    if value is None:
+        return []
+
+    raw_values = [value] if isinstance(value, str) else list(value)
+    regions: list[str] = []
+    seen: set[str] = set()
+
+    for raw_value in raw_values:
+        for part in str(raw_value).split(","):
+            region = part.strip().lower()
+            if not region:
+                continue
+            if region in seen:
+                continue
+            seen.add(region)
+            regions.append(region)
+
+    return regions

--- a/src/linode_image_lab/thaw.py
+++ b/src/linode_image_lab/thaw.py
@@ -1,0 +1,21 @@
+"""Thaw command placeholder."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .manifest import create_manifest
+
+
+def thaw_plan(*, regions: list[str], run_id: str | None = None, ttl: str | None = None) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="thaw",
+        mode="thaw",
+        regions=regions,
+        run_id=run_id,
+        ttl=ttl,
+        dry_run=True,
+        status="placeholder",
+    )
+    manifest["message"] = "thaw is a non-mutating placeholder in M1"
+    return manifest

--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -20,6 +20,12 @@ PRIVATE_URL_RE = re.compile(
 SECRET_VALUE_RE = re.compile(
     r"(?i)\b(?:token|secret|password|api[_-]?key)\s*[:=]\s*['\"](?!LINODE_TOKEN['\"])[^'\"\s]{8,}['\"]"
 )
+# Build these ranges from code points so the scanner cannot flag its own source.
+BIDI_CONTROL_CHARS = frozenset(
+    chr(codepoint)
+    for start, end in ((0x202A, 0x202E), (0x2066, 0x2069))
+    for codepoint in range(start, end + 1)
+)
 TEXT_SUFFIXES = {
     ".md",
     ".py",
@@ -62,6 +68,9 @@ def scan_public_safety(root: Path) -> list[str]:
             findings.append(f"{relative}: private URL detected")
         if SECRET_VALUE_RE.search(text):
             findings.append(f"{relative}: secret-like assignment detected")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if any(character in BIDI_CONTROL_CHARS for character in line):
+                findings.append(f"{relative}:{line_number}: hidden Unicode bidi control detected")
 
     return findings
 

--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -1,0 +1,82 @@
+"""Local public-safety validation."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BANNED_TERMS = (
+    "aka" + "mai",
+    "corp" + "orate email",
+    "internal user" + "name",
+    "proprietary ident" + "ifier",
+)
+EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.I)
+PRIVATE_URL_RE = re.compile(
+    r"https?://(?:localhost|127\.0\.0\.1|10\.|192\.168\.|172\.(?:1[6-9]|2[0-9]|3[0-1])\.|[^/\s]+\.internal\b|[^/\s]+\.corp\b)",
+    re.I,
+)
+SECRET_VALUE_RE = re.compile(
+    r"(?i)\b(?:token|secret|password|api[_-]?key)\s*[:=]\s*['\"](?!LINODE_TOKEN['\"])[^'\"\s]{8,}['\"]"
+)
+TEXT_SUFFIXES = {
+    ".md",
+    ".py",
+    ".txt",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".cfg",
+    ".sh",
+    ".mk",
+}
+SKIP_DIRS = {".git", ".mypy_cache", ".pytest_cache", "__pycache__"}
+
+
+def iter_text_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if path.is_file() and (path.suffix in TEXT_SUFFIXES or path.name == "Makefile"):
+            files.append(path)
+    return files
+
+
+def scan_public_safety(root: Path) -> list[str]:
+    findings: list[str] = []
+    for path in iter_text_files(root):
+        text = path.read_text(encoding="utf-8")
+        relative = path.relative_to(root)
+        lower_text = text.lower()
+
+        for term in BANNED_TERMS:
+            if term in lower_text:
+                findings.append(f"{relative}: restricted term detected")
+        if EMAIL_RE.search(text):
+            findings.append(f"{relative}: email-like value detected")
+        if PRIVATE_URL_RE.search(text):
+            findings.append(f"{relative}: private URL detected")
+        if SECRET_VALUE_RE.search(text):
+            findings.append(f"{relative}: secret-like assignment detected")
+
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    root = Path(args[0] if args else ".").resolve()
+    findings = scan_public_safety(root)
+    if findings:
+        for finding in findings:
+            print(finding, file=sys.stderr)
+        return 1
+    print("security-check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/sanitized/mock_resources.json
+++ b/tests/fixtures/sanitized/mock_resources.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "resource-expired",
+    "tags": [
+      "project=linode-image-lab",
+      "run_id=run-test",
+      "mode=freeze-thaw",
+      "component=builder",
+      "ttl=2026-01-01T00:00:00Z"
+    ]
+  },
+  {
+    "id": "resource-active",
+    "tags": [
+      "project=linode-image-lab",
+      "run_id=run-test",
+      "mode=freeze-thaw",
+      "component=builder",
+      "ttl=2030-01-01T00:00:00Z"
+    ]
+  }
+]

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from linode_image_lab.cleanup import select_cleanup_candidates
+
+
+class CleanupSelectionTests(unittest.TestCase):
+    def test_selects_only_expired_fully_tagged_resources(self) -> None:
+        fixture = Path("tests/fixtures/sanitized/mock_resources.json")
+        resources = json.loads(fixture.read_text(encoding="utf-8"))
+        resources.append({"id": "untagged", "tags": ["project=linode-image-lab"]})
+
+        selected = select_cleanup_candidates(
+            resources,
+            now=datetime(2026, 5, 1, tzinfo=UTC),
+        )
+
+        self.assertEqual([resource["id"] for resource in selected], ["resource-expired"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+
+from linode_image_lab.cli import main
+
+
+class CliTests(unittest.TestCase):
+    def test_plan_emits_sanitized_dry_run_preview(self) -> None:
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(
+                [
+                    "plan",
+                    "--region",
+                    "us-east,us-west",
+                    "--run-id",
+                    "run-test",
+                    "--ttl",
+                    "2030-01-01T00:00:00Z",
+                ]
+            )
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["command"], "plan")
+        self.assertEqual(payload["regions"], ["us-east", "us-west"])
+        self.assertIn("project=linode-image-lab", payload["tags"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+import unittest
+
+from linode_image_lab.manifest import create_manifest, generate_tags, serialize_manifest
+
+
+class ManifestTests(unittest.TestCase):
+    def test_generates_required_tags(self) -> None:
+        tags = generate_tags(
+            run_id="run-test",
+            mode="freeze-thaw",
+            component="builder",
+            ttl="2030-01-01T00:00:00Z",
+        )
+
+        self.assertEqual(
+            tags,
+            [
+                "project=linode-image-lab",
+                "run_id=run-test",
+                "mode=freeze-thaw",
+                "component=builder",
+                "ttl=2030-01-01T00:00:00Z",
+            ],
+        )
+
+    def test_creates_serializable_manifest(self) -> None:
+        manifest = create_manifest(
+            command="plan",
+            mode="freeze",
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+        )
+
+        serialized = serialize_manifest(manifest)
+        parsed = json.loads(serialized)
+
+        self.assertEqual(parsed["schema_version"], 1)
+        self.assertEqual(parsed["project"], "linode-image-lab")
+        self.assertEqual(parsed["planned_actions"][0]["region"], "us-east")
+        self.assertFalse(parsed["planned_actions"][0]["mutates"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+
+from linode_image_lab.redaction import REDACTION, redact, redact_text
+
+
+class RedactionTests(unittest.TestCase):
+    def test_redacts_sensitive_mapping_keys(self) -> None:
+        payload = {"token": "not-a-real-value", "env": "LINODE_TOKEN"}
+
+        self.assertEqual(redact(payload), {"token": REDACTION, "env": "LINODE_TOKEN"})
+
+    def test_redacts_token_like_text(self) -> None:
+        self.assertEqual(redact_text("Bearer abcdefgh123456"), f"Bearer {REDACTION}")
+        self.assertEqual(redact_text("token=abcdefgh123456"), f"token={REDACTION}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_regions.py
+++ b/tests/unit/test_regions.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import unittest
+
+from linode_image_lab.regions import parse_regions
+
+
+class RegionParsingTests(unittest.TestCase):
+    def test_parses_comma_separated_regions(self) -> None:
+        self.assertEqual(parse_regions("us-east, us-west"), ["us-east", "us-west"])
+
+    def test_parses_repeated_regions_and_deduplicates(self) -> None:
+        self.assertEqual(parse_regions(["us-east", "us-west,us-east"]), ["us-east", "us-west"])
+
+    def test_ignores_empty_values(self) -> None:
+        self.assertEqual(parse_regions(["", " us-east ,, "]), ["us-east"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from linode_image_lab.validation import scan_public_safety
+
+
+class ValidationTests(unittest.TestCase):
+    def test_reports_bidi_control_with_file_and_line(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "sample.py"
+            path.write_text("safe = True\nname = 'safe'" + chr(0x202E) + "\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, ["sample.py:2: hidden Unicode bidi control detected"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add repo-local execution rules, baseline docs, and Makefile validation targets.
- Add minimal stdlib Python CLI for dry-run plan output and placeholder freeze/thaw/freeze-thaw/cleanup commands.
- Add manifest/tag/redaction/region/cleanup helpers with unit tests and sanitized fixtures.

## Validation
- `make check`
- `make security-check`
- `PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east,us-west --run-id smoke-run --ttl 2030-01-01T00:00:00Z`

## Notes
- M1 intentionally does not mutate Linode resources.
- Cleanup selection is implemented against tagged mock resource data only.