### PR TITLE
[codex] fix security-check fixture placement

### DIFF
--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -40,6 +40,8 @@ TEXT_SUFFIXES = {
     ".mk",
 }
 SKIP_DIRS = {".git", ".mypy_cache", ".pytest_cache", "__pycache__"}
+FIXTURE_ROOT = Path("tests/fixtures")
+SANITIZED_FIXTURE_ROOT = FIXTURE_ROOT / "sanitized"
 
 
 def iter_text_files(root: Path) -> list[Path]:
@@ -52,8 +54,26 @@ def iter_text_files(root: Path) -> list[Path]:
     return files
 
 
-def scan_public_safety(root: Path) -> list[str]:
+def is_under(path: Path, parent: Path) -> bool:
+    return path == parent or parent in path.parents
+
+
+def scan_fixture_placement(root: Path) -> list[str]:
+    fixture_root = root / FIXTURE_ROOT
+    sanitized_root = root / SANITIZED_FIXTURE_ROOT
+    if not fixture_root.exists():
+        return []
+
     findings: list[str] = []
+    for path in fixture_root.rglob("*"):
+        if path.is_file() and not is_under(path, sanitized_root):
+            relative = path.relative_to(root)
+            findings.append(f"{relative}: fixture files must live under {SANITIZED_FIXTURE_ROOT}/")
+    return findings
+
+
+def scan_public_safety(root: Path) -> list[str]:
+    findings = scan_fixture_placement(root)
     for path in iter_text_files(root):
         text = path.read_text(encoding="utf-8")
         relative = path.relative_to(root)

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -8,6 +8,31 @@ from linode_image_lab.validation import scan_public_safety
 
 
 class ValidationTests(unittest.TestCase):
+    def test_allows_sanitized_fixture_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "tests" / "fixtures" / "sanitized" / "mock.json"
+            path.parent.mkdir(parents=True)
+            path.write_text("{}\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, [])
+
+    def test_reports_unsanitized_fixture_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "tests" / "fixtures" / "mock.json"
+            path.parent.mkdir(parents=True)
+            path.write_text("{}\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(
+            findings,
+            ["tests/fixtures/mock.json: fixture files must live under tests/fixtures/sanitized/"],
+        )
+
     def test_reports_bidi_control_with_file_and_line(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- Enforce that fixture files under `tests/fixtures/` must live below `tests/fixtures/sanitized/`.
- Report the offending fixture path when the public-safety scan finds an unsanitized fixture location.
- Add focused unit coverage for allowed sanitized fixture paths and disallowed unsanitized fixture paths.

## Validation

- `make check` passed: `security-check passed`; `Ran 12 tests ... OK`.
- `make security-check` passed: `security-check passed`.

## Residual Risks

- The scanner remains intentionally small and local; it enforces fixture placement and existing public-safety patterns, but it is not a full DLP system.