### PR TITLE
[codex] add minimal CI check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,27 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: make check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run canonical validation
+        run: make check


### PR DESCRIPTION
## Summary

- Add a minimal GitHub Actions workflow for pull requests and pushes to `main`.
- Use Python 3.12 and the repo's canonical `make check` validation path.
- Keep the workflow public-safe and non-mutating with read-only contents permissions and no secrets or Linode token references.

## Validation

- `make check` passed locally.
- Workflow YAML parsed successfully with local Psych syntax parsing.
- `actionlint` is not installed in this environment, so full Actions validation will occur on GitHub.
- Verified the workflow does not reference `LINODE_TOKEN`, `secrets.*`, scheduled triggers, dispatch triggers, Linode commands, or deployment commands.

## Residual Risks

- The first GitHub-hosted run will verify the exact runner image and Actions behavior.
- Branch protection required checks will still need to be configured after this workflow exists on `main`.

## Expected GitHub Actions Check

- `Check / make check`
