### PR TITLE
[codex] Implement M2 single-region capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,12 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Repo Scope
 
 - This repo contains a public-safe Linode Image Lab scaffold.
-- M1 behavior is limited to dry-run custom image capture/deploy planning,
+- M1 behavior established dry-run custom image capture/deploy planning,
   manifest modeling, tag contracts, cleanup selection logic, docs, and tests.
-- Do not add real Linode mutation behavior until a later milestone explicitly
-  asks for it.
+- M2 permits explicit single-region capture execution only through
+  `capture --execute`; default behavior remains non-mutating.
+- Do not add deploy, capture-deploy, multi-region execution, or additional real
+  Linode mutation behavior until a later milestone explicitly asks for it.
 
 ## Public-Safe Boundary
 
@@ -18,6 +20,7 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Do not commit secret values, private identifiers, non-public URLs, or
   workplace metadata.
 - `LINODE_TOKEN` may appear only as an environment variable name.
+- Normal stdout and stderr must not expose provider resource identifiers.
 - Fixtures must be sanitized and live under `tests/fixtures/sanitized/`.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Linode Image Lab
 
-Linode Image Lab is a small Python scaffold for modeling custom image
-capture/deploy workflows before any real cloud mutation behavior exists.
+Linode Image Lab is a small Python scaffold for modeling and safely exercising
+custom image capture/deploy workflows.
 
-M1 is intentionally conservative:
+M2 remains intentionally conservative:
 
 - `plan` emits a dry-run, sanitized manifest-like preview.
-- `capture`, `deploy`, and `capture-deploy` are explicit placeholders.
+- `capture` is dry-run by default.
+- `capture --execute` is the only command that can mutate Linode resources.
+- `deploy` and `capture-deploy` remain explicit placeholders.
 - `cleanup` is first-class and independently runnable.
 - Manifest schema, rediscoverable tags, and cleanup selection are the foundation.
 
@@ -25,8 +27,8 @@ make check
 PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east --run-id demo-run
 ```
 
-`LINODE_TOKEN` is reserved for later Linode API work. M1 does not read or use
-the value.
+`LINODE_TOKEN` is read only when `capture --execute` is used. Dry-run commands
+do not read the token, call Linode, or mutate resources.
 
 ## Required Tags
 
@@ -43,10 +45,17 @@ Every modeled resource uses rediscoverable tags:
 ```sh
 PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east,us-west
 PYTHONPATH=src python3 -m linode_image_lab.cli capture --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli capture --region us-east --execute --source-image linode/debian12 --type g6-nanode-1
 PYTHONPATH=src python3 -m linode_image_lab.cli deploy --region us-east
 PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy --region us-east
 PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
 ```
 
-The placeholder commands return structured JSON and do not mutate Linode
-resources.
+`capture --execute` requires exactly one region, `--source-image`, `--type`, and
+`LINODE_TOKEN`. It creates a temporary capture-source Linode, waits for it to be
+ready, powers it off, captures a custom image from its disk, waits for the image,
+then deletes the temporary source unless `--preserve-source` is provided.
+
+Normal stdout is a redacted, export-safe manifest view. Local in-memory
+manifests may retain provider identifiers needed for cleanup and debugging, but
+serialized output redacts those identifiers.

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -10,7 +10,8 @@ The capture flow creates a reusable custom image from an existing Linode or
 disk. By default, the command returns a dry-run manifest and performs no Linode
 action.
 
-`capture --execute` is the only mutating M2 command. It requires:
+`capture --execute` is the only mutating M2 command. It creates Linode
+resources and may incur account charges until cleanup completes. It requires:
 
 - exactly one `--region`,
 - `--source-image`,

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -1,22 +1,44 @@
 # Capture-Deploy Workflow
 
-M1 documents the intended workflow shape while keeping execution non-mutating.
+This document describes the current capture/deploy workflow shape. M2 adds
+single-region capture execution only; deploy and capture-deploy execution remain
+out of scope.
 
 ## Capture
 
 The capture flow creates a reusable custom image from an existing Linode or
-disk. In M1, the command returns a placeholder manifest and performs no Linode
+disk. By default, the command returns a dry-run manifest and performs no Linode
 action.
+
+`capture --execute` is the only mutating M2 command. It requires:
+
+- exactly one `--region`,
+- `--source-image`,
+- `--type`,
+- `LINODE_TOKEN`.
+
+Execution steps:
+
+1. preflight token access without mutating resources,
+2. create a temporary capture-source Linode from the source image,
+3. wait until the source is ready,
+4. validate requested region, required tags, and disk presence,
+5. power off the source,
+6. create a custom image from the selected disk,
+7. wait until the image is available,
+8. delete the temporary source unless `--preserve-source` is set.
+
+The custom image is preserved by default because it is the capture deliverable.
 
 ## Deploy
 
-The deploy flow creates a new Linode from a custom image. In M1, the command
+The deploy flow creates a new Linode from a custom image. The command currently
 returns a placeholder manifest and performs no Linode action.
 
 ## Capture-Deploy
 
 The capture-deploy flow validates the end-to-end path by capturing a custom
-image, then deploying a new Linode from it. In M1, the command returns a
+image, then deploying a new Linode from it. The command currently returns a
 placeholder manifest with `mode=capture-deploy`.
 
 ## Cleanup
@@ -30,3 +52,8 @@ required tags are present:
 - `mode=<capture|deploy|capture-deploy>`
 - `component=<capture|deploy>`
 - `ttl=<timestamp>`
+
+Execute-mode capture cleanup is narrower than general cleanup. It only attempts
+to delete the current run's temporary capture-source Linode, and only when that
+resource has all required tags matching the current run. If tags are missing or
+do not match, cleanup is skipped and the manifest reports the skip.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -8,6 +8,7 @@ This repository is intended to be safe for public publication.
 - Environment variable names such as `LINODE_TOKEN`.
 - Sanitized fixtures under `tests/fixtures/sanitized/`.
 - Deterministic mock resource identifiers.
+- Redacted/export-safe manifest examples.
 
 ## Not Allowed
 
@@ -16,6 +17,7 @@ This repository is intended to be safe for public publication.
 - Non-public service URLs.
 - Private account names or machine names.
 - Workplace metadata unrelated to this public project.
+- Provider resource identifiers in normal stdout or stderr examples.
 
 ## Review Checklist
 
@@ -23,5 +25,7 @@ Before opening a PR:
 
 - run `make check`,
 - confirm fixtures are sanitized,
-- confirm commands remain dry-run or placeholder-only,
+- confirm dry-run commands remain non-mutating,
+- confirm real mutation remains limited to explicit `capture --execute`,
+- confirm cleanup only targets resources with complete matching tags,
 - confirm docs describe behavior without private context.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,7 +1,7 @@
 # Design
 
-Linode Image Lab M1 models the control-plane contract for a future custom image
-capture/deploy workflow without implementing real Linode mutations.
+Linode Image Lab models the control-plane contract for custom image
+capture/deploy workflows while keeping mutation paths explicit and narrow.
 
 ## Goals
 
@@ -9,21 +9,25 @@ capture/deploy workflow without implementing real Linode mutations.
 - Create sanitized manifest previews for dry-run planning.
 - Define a stable tag contract for resource rediscovery.
 - Make cleanup selection testable without cloud access.
+- Allow single-region capture execution only after explicit opt-in.
 
 ## Non-Goals
 
-- No real Linode API mutations.
-- No deployment, GitHub Enterprise, or external scheduler integration.
+- No implicit Linode API mutations.
+- No deploy execution, capture-deploy execution, multi-region execution,
+  GitHub Actions mutation, or external scheduler integration.
 - CI exists to run `make check`.
 
 ## Components
 
 - `cli.py` owns command parsing and JSON output.
-- `manifest.py` owns manifest creation, tag generation, and serialization.
+- `capture.py` owns dry-run capture manifests and execute-mode orchestration.
+- `manifest.py` owns manifest creation, tag generation, and sanitized
+  serialization.
 - `regions.py` owns one-or-many region parsing.
 - `cleanup.py` owns tag-based cleanup candidate selection.
 - `redaction.py` owns recursive output sanitization.
-- `linode_api.py` is a placeholder boundary for a future client.
+- `linode_api.py` owns the mockable Linode client boundary.
 
 ## Manifest Foundation
 
@@ -31,3 +35,26 @@ Manifests are plain JSON-compatible dictionaries. They include schema version,
 project, command, mode, regions, timestamps, dry-run status, tags, and planned
 actions. Future milestones can add fields while preserving the required tag
 contract.
+
+M2 capture execution adds `execution_mode`, ordered `steps`, `resources`,
+`capture_source`, `custom_image`, and `cleanup` fields. Internal manifests may
+carry provider resource identifiers required for cleanup and debugging. Normal
+stdout uses sanitized serialization, which redacts provider identifiers before
+printing.
+
+## Capture Execution Boundary
+
+`capture` without `--execute` remains non-mutating and does not read
+`LINODE_TOKEN`. `capture --execute` requires exactly one region, a source image,
+a Linode type, and `LINODE_TOKEN`.
+
+The execute flow is intentionally linear:
+
+1. preflight the token with non-mutating API calls,
+2. create a tagged temporary capture-source Linode,
+3. wait for readiness,
+4. validate region, tags, and disk presence,
+5. shut down the source Linode,
+6. capture a custom image from the selected disk,
+7. wait for image availability,
+8. delete or preserve the source according to explicit flags.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,13 +1,32 @@
 # Security
 
-M1 is designed to be public-safe and non-mutating.
+Linode Image Lab is designed to be public-safe by default. Dry-run behavior is
+non-mutating; M2 capture execution requires explicit opt-in.
 
 ## Token Handling
 
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
-- The CLI does not read token values in M1.
+- The CLI reads `LINODE_TOKEN` only for `capture --execute`.
+- Dry-run commands do not read token values.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
+- Normal stdout and stderr must not print tokens, authorization headers, root
+  passwords, SSH keys, cloud-init secrets, or provider resource identifiers.
+
+## Execute Permissions
+
+`capture --execute` needs a personal access token or equivalent OAuth access
+that can:
+
+- read the current profile for preflight,
+- create, read, shut down, and delete temporary Linodes,
+- create and read custom images,
+- apply tags to created resources.
+
+In Linode scope terms, this generally means `linodes:read_write` and
+`images:read_write`, plus account permissions or grants that allow Linode
+creation and tagging. If tags cannot be applied or later verified, execution
+fails safely because cleanup depends on rediscoverable tags.
 
 ## Public-Safety Scan
 
@@ -26,6 +45,12 @@ loss prevention system.
 
 ## Mutation Safety
 
-`plan` is dry-run only. `capture`, `deploy`, and `capture-deploy` return
-explicit placeholder responses. `cleanup` currently selects candidates from
-provided data structures and does not call Linode.
+`plan` is dry-run only. `capture` is dry-run unless `--execute` is provided.
+`deploy` and `capture-deploy` return explicit placeholder responses. `cleanup`
+currently selects candidates from provided data structures and does not call
+Linode.
+
+`capture --execute` fails before mutation if required options or `LINODE_TOKEN`
+are missing. It performs non-mutating token preflight before creating resources.
+Partial-failure cleanup only targets resources whose required tags exactly
+match the current run.

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -1,21 +1,319 @@
-"""Capture command placeholder."""
+"""Capture command planning and execution orchestration."""
 
 from __future__ import annotations
 
+import re
+import secrets
+from dataclasses import dataclass
 from typing import Any
 
-from .manifest import create_manifest
+from .linode_api import LinodeClient, LinodeClientProtocol
+from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
 
 
-def capture_plan(*, regions: list[str], run_id: str | None = None, ttl: str | None = None) -> dict[str, Any]:
-    manifest = create_manifest(
-        command="capture",
-        mode="capture",
+class CaptureError(ValueError):
+    """Raised when capture cannot safely complete."""
+
+    def __init__(self, message: str, manifest: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.manifest = manifest
+
+
+@dataclass(frozen=True)
+class CaptureOptions:
+    regions: list[str]
+    run_id: str | None = None
+    ttl: str | None = None
+    execute: bool = False
+    source_image: str | None = None
+    instance_type: str | None = None
+    image_label: str | None = None
+    preserve_source: bool = False
+
+
+def capture_plan(
+    *,
+    regions: list[str],
+    run_id: str | None = None,
+    ttl: str | None = None,
+    execute: bool = False,
+    source_image: str | None = None,
+    instance_type: str | None = None,
+    image_label: str | None = None,
+    preserve_source: bool = False,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    options = CaptureOptions(
         regions=regions,
         run_id=run_id,
         ttl=ttl,
-        dry_run=True,
-        status="placeholder",
+        execute=execute,
+        source_image=source_image,
+        instance_type=instance_type,
+        image_label=image_label,
+        preserve_source=preserve_source,
     )
-    manifest["message"] = "capture is a non-mutating placeholder in M1"
+    if not execute:
+        return dry_run_manifest(options)
+    return execute_capture(options, client=client)
+
+
+def dry_run_manifest(options: CaptureOptions) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="capture",
+        mode="capture",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=True,
+        status="planned",
+    )
+    manifest["execution_mode"] = "dry-run"
+    manifest["message"] = "capture is non-mutating unless --execute is provided"
     return manifest
+
+
+def execute_capture(
+    options: CaptureOptions,
+    *,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    validate_execute_options(options)
+    manifest = create_manifest(
+        command="capture",
+        mode="capture",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=False,
+        status="running",
+    )
+    manifest["execution_mode"] = "execute"
+    manifest["steps"] = []
+    manifest["resources"] = []
+    manifest["capture_source"] = {}
+    manifest["custom_image"] = {}
+    manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+    for action in manifest["planned_actions"]:
+        action["mutates"] = True
+
+    run_client = client or LinodeClient.from_env()
+    capture_source: dict[str, Any] | None = None
+    custom_image: dict[str, Any] | None = None
+
+    try:
+        append_step(manifest, "preflight", mutates=False, status="running")
+        run_client.preflight()
+        finish_step(manifest, "preflight")
+
+        tags = list(manifest["tags"])
+        region = options.regions[0]
+        source_label = f"lil-{safe_label_suffix(manifest['run_id'])}-source"
+        image_label = options.image_label or f"lil-{safe_label_suffix(manifest['run_id'])}-image"
+
+        append_step(manifest, "create_capture_source", mutates=True, status="running")
+        capture_source = run_client.create_instance(
+            region=region,
+            source_image=required_text(options.source_image),
+            instance_type=required_text(options.instance_type),
+            label=source_label,
+            tags=tags,
+            root_password=secrets.token_urlsafe(32),
+        )
+        capture_source["resource_type"] = "linode"
+        manifest["capture_source"] = dict(capture_source)
+        manifest["resources"].append(dict(capture_source))
+        finish_step(manifest, "create_capture_source")
+
+        append_step(manifest, "wait_capture_source_ready", mutates=False, status="running")
+        capture_source = merge_resource(
+            capture_source,
+            run_client.wait_instance_ready(required_int(capture_source.get("linode_id"))),
+        )
+        manifest["capture_source"] = dict(capture_source)
+        manifest["resources"][0] = dict(capture_source)
+        finish_step(manifest, "wait_capture_source_ready")
+
+        append_step(manifest, "validate_capture_source", mutates=False, status="running")
+        validate_created_resource(capture_source, required_tags=tags, region=region)
+        disks = run_client.list_disks(required_int(capture_source.get("linode_id")))
+        disk = first_disk(disks)
+        capture_source["disk_id"] = disk["disk_id"]
+        manifest["capture_source"] = dict(capture_source)
+        manifest["resources"][0] = dict(capture_source)
+        finish_step(manifest, "validate_capture_source")
+
+        append_step(manifest, "shutdown_capture_source", mutates=True, status="running")
+        run_client.shutdown_instance(required_int(capture_source.get("linode_id")))
+        finish_step(manifest, "shutdown_capture_source")
+
+        append_step(manifest, "wait_capture_source_offline", mutates=False, status="running")
+        capture_source = merge_resource(
+            capture_source,
+            run_client.wait_instance_offline(required_int(capture_source.get("linode_id"))),
+        )
+        manifest["capture_source"] = dict(capture_source)
+        manifest["resources"][0] = dict(capture_source)
+        finish_step(manifest, "wait_capture_source_offline")
+
+        append_step(manifest, "capture_custom_image", mutates=True, status="running")
+        custom_image = run_client.capture_image(
+            disk_id=required_int(capture_source.get("disk_id")),
+            label=image_label,
+            tags=tags,
+            description=f"linode-image-lab capture run {manifest['run_id']}",
+            cloud_init=True,
+        )
+        custom_image["resource_type"] = "image"
+        manifest["custom_image"] = dict(custom_image)
+        manifest["resources"].append(dict(custom_image))
+        finish_step(manifest, "capture_custom_image")
+
+        append_step(manifest, "wait_custom_image_available", mutates=False, status="running")
+        custom_image = merge_resource(
+            custom_image,
+            run_client.wait_image_available(required_text(custom_image.get("image_id"))),
+        )
+        validate_created_resource(custom_image, required_tags=tags)
+        manifest["custom_image"] = dict(custom_image)
+        manifest["resources"][1] = dict(custom_image)
+        finish_step(manifest, "wait_custom_image_available")
+
+        cleanup_capture_source(
+            manifest,
+            run_client,
+            capture_source=capture_source,
+            preserve_source=options.preserve_source,
+            required_tags=tags,
+        )
+        manifest["status"] = "succeeded"
+        return manifest
+    except Exception as exc:
+        mark_running_step_failed(manifest)
+        manifest["status"] = "failed"
+        manifest["errors"] = [safe_error_message(exc)]
+        if capture_source is not None and not cleanup_started(manifest):
+            try:
+                cleanup_capture_source(
+                    manifest,
+                    run_client,
+                    capture_source=capture_source,
+                    preserve_source=options.preserve_source,
+                    required_tags=list(manifest["tags"]),
+                )
+            except Exception:
+                mark_running_step_failed(manifest)
+                manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+        raise CaptureError("capture --execute failed", manifest) from exc
+
+
+def validate_execute_options(options: CaptureOptions) -> None:
+    if len(options.regions) != 1:
+        raise CaptureError("capture --execute requires exactly one region")
+    if not options.source_image:
+        raise CaptureError("capture --execute requires --source-image")
+    if not options.instance_type:
+        raise CaptureError("capture --execute requires --type")
+
+
+def cleanup_capture_source(
+    manifest: dict[str, Any],
+    client: LinodeClientProtocol,
+    *,
+    capture_source: dict[str, Any],
+    preserve_source: bool,
+    required_tags: list[str],
+) -> None:
+    append_step(manifest, "cleanup_capture_source", mutates=not preserve_source, status="running")
+    cleanup = {"status": "not_started", "deleted": [], "preserved": []}
+    if preserve_source:
+        cleanup["status"] = "preserved"
+        cleanup["preserved"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
+    elif has_required_tags(capture_source, required_tags):
+        client.delete_instance(required_int(capture_source.get("linode_id")))
+        cleanup["status"] = "deleted"
+        cleanup["deleted"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
+    else:
+        cleanup["status"] = "skipped_tag_mismatch"
+        cleanup["preserved"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
+    manifest["cleanup"] = cleanup
+    finish_step(manifest, "cleanup_capture_source")
+
+
+def append_step(manifest: dict[str, Any], name: str, *, mutates: bool, status: str) -> None:
+    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+
+
+def finish_step(manifest: dict[str, Any], name: str) -> None:
+    for step in reversed(manifest["steps"]):
+        if step["name"] == name:
+            step["status"] = "succeeded"
+            return
+
+
+def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+    for step in reversed(manifest.get("steps", [])):
+        if step.get("status") == "running":
+            step["status"] = "failed"
+            return
+
+
+def cleanup_started(manifest: dict[str, Any]) -> bool:
+    return any(step.get("name") == "cleanup_capture_source" for step in manifest.get("steps", []))
+
+
+def validate_created_resource(
+    resource: dict[str, Any],
+    *,
+    required_tags: list[str],
+    region: str | None = None,
+) -> None:
+    if region is not None and resource.get("region") != region:
+        raise CaptureError("created capture source is not in the requested region")
+    if not has_required_tags(resource, required_tags):
+        raise CaptureError("created resource is missing required capture tags")
+
+
+def has_required_tags(resource: dict[str, Any], required_tags: list[str]) -> bool:
+    tags = tags_to_dict(resource.get("tags", []))
+    expected = tags_to_dict(required_tags)
+    return all(key in tags and tags[key] == expected[key] for key in REQUIRED_TAG_KEYS)
+
+
+def first_disk(disks: list[dict[str, Any]]) -> dict[str, Any]:
+    if not disks:
+        raise CaptureError("capture source has no disk to image")
+    disk = disks[0]
+    disk_id = disk.get("disk_id", disk.get("id"))
+    if disk_id is None:
+        raise CaptureError("capture source disk is missing an id")
+    return {"disk_id": disk_id}
+
+
+def merge_resource(current: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(current)
+    merged.update({key: value for key, value in update.items() if value is not None})
+    return merged
+
+
+def required_text(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CaptureError("required capture value is missing")
+    return value
+
+
+def required_int(value: object) -> int:
+    if not isinstance(value, int):
+        raise CaptureError("required provider resource id is missing")
+    return value
+
+
+def safe_label_suffix(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
+    return (normalized or "run")[:32]
+
+
+def safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, CaptureError):
+        return str(exc)
+    return exc.__class__.__name__

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any
 
 from .cleanup import select_cleanup_candidates
-from .capture import capture_plan
+from .capture import CaptureError, capture_plan
 from .deploy import deploy_plan
 from .manifest import create_manifest, serialize_manifest
 from .regions import parse_regions
@@ -37,8 +37,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Workflow mode to model.",
     )
 
-    capture = subparsers.add_parser("capture", help="Placeholder capture command.")
+    capture = subparsers.add_parser("capture", help="Plan or execute a single-region capture.")
     add_region_args(capture, required=True)
+    capture.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    capture.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
+    capture.add_argument("--type", dest="instance_type", help="Linode type for the temporary capture Linode.")
+    capture.add_argument("--image-label", help="Optional label for the captured custom image.")
+    capture.add_argument(
+        "--preserve-source",
+        action="store_true",
+        help="Keep the temporary capture-source Linode after execution.",
+    )
 
     deploy = subparsers.add_parser("deploy", help="Placeholder deploy command.")
     add_region_args(deploy, required=True)
@@ -66,7 +75,16 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     if args.command == "capture":
-        return capture_plan(regions=parse_regions(args.region), run_id=args.run_id, ttl=args.ttl)
+        return capture_plan(
+            regions=parse_regions(args.region),
+            run_id=args.run_id,
+            ttl=args.ttl,
+            execute=args.execute,
+            source_image=args.source_image,
+            instance_type=args.instance_type,
+            image_label=args.image_label,
+            preserve_source=args.preserve_source,
+        )
 
     if args.command == "deploy":
         return deploy_plan(regions=parse_regions(args.region), run_id=args.run_id, ttl=args.ttl)
@@ -81,7 +99,7 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
             dry_run=True,
             status="placeholder",
         )
-        manifest["message"] = "capture-deploy is a non-mutating placeholder in M1"
+        manifest["message"] = "capture-deploy is a non-mutating placeholder"
         return manifest
 
     if args.command == "cleanup":
@@ -94,7 +112,7 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
             dry_run=True,
             status="placeholder",
         )
-        manifest["message"] = "cleanup is independently runnable and non-mutating in M1"
+        manifest["message"] = "cleanup is independently runnable and non-mutating"
         manifest["cleanup_candidates"] = select_cleanup_candidates([])
         return manifest
 
@@ -106,6 +124,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         manifest = command_manifest(args)
+    except CaptureError as exc:
+        if exc.manifest is not None:
+            sys.stdout.write(serialize_manifest(exc.manifest))
+            sys.stderr.write("capture --execute failed\n")
+            return 1
+        parser.error(str(exc))
     except ValueError as exc:
         parser.error(str(exc))
     sys.stdout.write(serialize_manifest(manifest))

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -17,5 +17,5 @@ def deploy_plan(*, regions: list[str], run_id: str | None = None, ttl: str | Non
         dry_run=True,
         status="placeholder",
     )
-    manifest["message"] = "deploy is a non-mutating placeholder in M1"
+    manifest["message"] = "deploy is a non-mutating placeholder"
     return manifest

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -1,20 +1,229 @@
-"""Placeholder Linode API boundary.
-
-M1 intentionally performs no Linode mutations. Future milestones can replace
-this boundary with a real client while keeping command modules small.
-"""
+"""Linode API boundary for capture execution."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+TOKEN_ENV_NAME = "LINODE_TOKEN"
+DEFAULT_API_BASE_URL = "https://api.linode.com/v4"
+
+
+class LinodeApiError(ValueError):
+    """Raised when the Linode API boundary cannot complete a requested action."""
+
+
+class LinodeTokenError(LinodeApiError):
+    """Raised when execute mode lacks a usable Linode token."""
+
+
+class LinodeClientProtocol(Protocol):
+    def preflight(self) -> None: ...
+
+    def create_instance(
+        self,
+        *,
+        region: str,
+        source_image: str,
+        instance_type: str,
+        label: str,
+        tags: list[str],
+        root_password: str,
+    ) -> dict[str, Any]: ...
+
+    def wait_instance_ready(self, linode_id: int) -> dict[str, Any]: ...
+
+    def list_disks(self, linode_id: int) -> list[dict[str, Any]]: ...
+
+    def shutdown_instance(self, linode_id: int) -> dict[str, Any]: ...
+
+    def wait_instance_offline(self, linode_id: int) -> dict[str, Any]: ...
+
+    def capture_image(
+        self,
+        *,
+        disk_id: int,
+        label: str,
+        tags: list[str],
+        description: str,
+        cloud_init: bool,
+    ) -> dict[str, Any]: ...
+
+    def wait_image_available(self, image_id: str) -> dict[str, Any]: ...
+
+    def delete_instance(self, linode_id: int) -> dict[str, Any]: ...
 
 
 @dataclass(frozen=True)
 class LinodeClient:
-    token_env_name: str = "LINODE_TOKEN"
+    """Small HTTP client used only after the user opts into execution."""
 
-    def mutation_enabled(self) -> bool:
-        return False
+    token: str = field(repr=False)
+    api_base_url: str = DEFAULT_API_BASE_URL
+    timeout_seconds: float = 30
+    poll_interval_seconds: float = 5
+    max_wait_seconds: float = 900
 
-    def list_resources(self) -> list[dict[str, object]]:
-        return []
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "LinodeClient":
+        values = env if env is not None else os.environ
+        token = values.get(TOKEN_ENV_NAME)
+        if not token:
+            raise LinodeTokenError(f"{TOKEN_ENV_NAME} is required for capture --execute")
+        return cls(token=token)
+
+    def preflight(self) -> None:
+        self._request("GET", "/profile")
+        self._request("GET", "/profile/grants", allow_empty=True)
+
+    def create_instance(
+        self,
+        *,
+        region: str,
+        source_image: str,
+        instance_type: str,
+        label: str,
+        tags: list[str],
+        root_password: str,
+    ) -> dict[str, Any]:
+        payload = {
+            "booted": True,
+            "image": source_image,
+            "label": label,
+            "region": region,
+            "root_pass": root_password,
+            "tags": tags,
+            "type": instance_type,
+        }
+        response = self._request("POST", "/linode/instances", payload)
+        return self._instance_resource(response)
+
+    def wait_instance_ready(self, linode_id: int) -> dict[str, Any]:
+        return self._wait_for_instance_status(linode_id, {"running"})
+
+    def list_disks(self, linode_id: int) -> list[dict[str, Any]]:
+        response = self._request("GET", f"/linode/instances/{linode_id}/disks")
+        disks = response.get("data", []) if isinstance(response, dict) else []
+        return [disk for disk in disks if isinstance(disk, dict)]
+
+    def shutdown_instance(self, linode_id: int) -> dict[str, Any]:
+        self._request("POST", f"/linode/instances/{linode_id}/shutdown", {})
+        return {"linode_id": linode_id, "action": "shutdown"}
+
+    def wait_instance_offline(self, linode_id: int) -> dict[str, Any]:
+        return self._wait_for_instance_status(linode_id, {"offline"})
+
+    def capture_image(
+        self,
+        *,
+        disk_id: int,
+        label: str,
+        tags: list[str],
+        description: str,
+        cloud_init: bool,
+    ) -> dict[str, Any]:
+        payload = {
+            "cloud_init": cloud_init,
+            "description": description,
+            "disk_id": disk_id,
+            "label": label,
+            "tags": tags,
+        }
+        response = self._request("POST", "/images", payload)
+        return self._image_resource(response)
+
+    def wait_image_available(self, image_id: str) -> dict[str, Any]:
+        escaped = quote(image_id, safe="")
+
+        def current() -> dict[str, Any]:
+            response = self._request("GET", f"/images/{escaped}")
+            return self._image_resource(response)
+
+        return self._wait_until(current, lambda resource: resource.get("status") == "available")
+
+    def delete_instance(self, linode_id: int) -> dict[str, Any]:
+        self._request("DELETE", f"/linode/instances/{linode_id}")
+        return {"linode_id": linode_id, "deleted": True}
+
+    def _wait_for_instance_status(self, linode_id: int, statuses: set[str]) -> dict[str, Any]:
+        def current() -> dict[str, Any]:
+            response = self._request("GET", f"/linode/instances/{linode_id}")
+            return self._instance_resource(response)
+
+        return self._wait_until(current, lambda resource: str(resource.get("status")) in statuses)
+
+    def _wait_until(
+        self,
+        current: Any,
+        done: Any,
+    ) -> dict[str, Any]:
+        deadline = time.monotonic() + self.max_wait_seconds
+        resource = current()
+        while not done(resource):
+            if time.monotonic() >= deadline:
+                raise LinodeApiError("timed out waiting for Linode resource readiness")
+            time.sleep(self.poll_interval_seconds)
+            resource = current()
+        return resource
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        allow_empty: bool = False,
+    ) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = Request(
+            f"{self.api_base_url}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+        )
+
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                text = response.read().decode("utf-8")
+        except HTTPError as exc:
+            if exc.code in {401, 403}:
+                raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API") from exc
+            raise LinodeApiError(f"Linode API request failed with status {exc.code}") from exc
+        except OSError as exc:
+            raise LinodeApiError("Linode API request failed") from exc
+
+        if not text:
+            return {} if allow_empty else {}
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+        raise LinodeApiError("Linode API returned an unexpected response")
+
+    @staticmethod
+    def _instance_resource(response: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "linode_id": response.get("id"),
+            "label": response.get("label"),
+            "region": response.get("region"),
+            "status": response.get("status"),
+            "tags": response.get("tags", []),
+        }
+
+    @staticmethod
+    def _image_resource(response: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "image_id": response.get("id"),
+            "label": response.get("label"),
+            "status": response.get("status"),
+            "tags": response.get("tags", []),
+        }

--- a/src/linode_image_lab/redaction.py
+++ b/src/linode_image_lab/redaction.py
@@ -11,10 +11,23 @@ SENSITIVE_KEY_RE = re.compile(r"(token|secret|password|api[_-]?key|credential)",
 TOKEN_TEXT_RE = re.compile(
     r"(?i)\b(bearer\s+)[a-z0-9._~+/=-]{8,}|\b(token|secret|password)=([^\s]+)"
 )
+PROVIDER_IDENTIFIER_KEYS = {
+    "account_id",
+    "disk_id",
+    "image_id",
+    "linode_id",
+    "provider_id",
+    "resource_id",
+    "user_id",
+}
 
 
 def is_sensitive_key(key: str) -> bool:
     return bool(SENSITIVE_KEY_RE.search(key))
+
+
+def is_provider_identifier_key(key: str) -> bool:
+    return key in PROVIDER_IDENTIFIER_KEYS
 
 
 def redact_text(value: str) -> str:
@@ -38,7 +51,10 @@ def redact(value: Any) -> Any:
         redacted: dict[str, Any] = {}
         for key, item in value.items():
             key_text = str(key)
-            redacted[key_text] = REDACTION if is_sensitive_key(key_text) else redact(item)
+            if is_sensitive_key(key_text) or is_provider_identifier_key(key_text):
+                redacted[key_text] = REDACTION
+            else:
+                redacted[key_text] = redact(item)
         return redacted
 
     if isinstance(value, str):

--- a/src/linode_image_lab/redaction.py
+++ b/src/linode_image_lab/redaction.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 REDACTION = "[REDACTED]"
-SENSITIVE_KEY_RE = re.compile(r"(token|secret|password|api[_-]?key|credential)", re.I)
+SENSITIVE_KEY_RE = re.compile(r"(token|secret|password|root[_-]?pass|api[_-]?key|credential)", re.I)
 TOKEN_TEXT_RE = re.compile(
     r"(?i)\b(bearer\s+)[a-z0-9._~+/=-]{8,}|\b(token|secret|password)=([^\s]+)"
 )

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from linode_image_lab.capture import CaptureError, capture_plan
+from linode_image_lab.linode_api import LinodeTokenError
+from linode_image_lab.manifest import serialize_manifest
+
+
+class FakeLinodeClient:
+    def __init__(self, *, missing_create_tags: bool = False) -> None:
+        self.calls: list[str] = []
+        self.create_tags: list[str] = []
+        self.image_tags: list[str] = []
+        self.deleted: list[int] = []
+        self.missing_create_tags = missing_create_tags
+
+    def preflight(self) -> None:
+        self.calls.append("preflight")
+
+    def create_instance(
+        self,
+        *,
+        region: str,
+        source_image: str,
+        instance_type: str,
+        label: str,
+        tags: list[str],
+        root_password: str,
+    ) -> dict[str, object]:
+        self.calls.append("create_instance")
+        self.create_tags = tags
+        self.root_password_length = len(root_password)
+        return {
+            "linode_id": 123,
+            "label": label,
+            "region": region,
+            "status": "provisioning",
+            "tags": [] if self.missing_create_tags else tags,
+        }
+
+    def wait_instance_ready(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("wait_instance_ready")
+        return {
+            "linode_id": linode_id,
+            "region": "us-east",
+            "status": "running",
+            "tags": [] if self.missing_create_tags else self.create_tags,
+        }
+
+    def list_disks(self, linode_id: int) -> list[dict[str, object]]:
+        self.calls.append("list_disks")
+        return [{"disk_id": 456}]
+
+    def shutdown_instance(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("shutdown_instance")
+        return {"linode_id": linode_id}
+
+    def wait_instance_offline(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("wait_instance_offline")
+        return {
+            "linode_id": linode_id,
+            "region": "us-east",
+            "status": "offline",
+            "tags": self.create_tags,
+        }
+
+    def capture_image(
+        self,
+        *,
+        disk_id: int,
+        label: str,
+        tags: list[str],
+        description: str,
+        cloud_init: bool,
+    ) -> dict[str, object]:
+        self.calls.append("capture_image")
+        self.image_tags = tags
+        return {
+            "image_id": "private/789",
+            "label": label,
+            "status": "creating",
+            "tags": tags,
+        }
+
+    def wait_image_available(self, image_id: str) -> dict[str, object]:
+        self.calls.append("wait_image_available")
+        return {
+            "image_id": image_id,
+            "status": "available",
+            "tags": self.image_tags,
+        }
+
+    def delete_instance(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("delete_instance")
+        self.deleted.append(linode_id)
+        return {"linode_id": linode_id, "deleted": True}
+
+
+class ExplodingClient:
+    def preflight(self) -> None:
+        raise AssertionError("dry-run must not call the client")
+
+
+class InvalidTokenClient(FakeLinodeClient):
+    def preflight(self) -> None:
+        self.calls.append("preflight")
+        raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
+
+
+class CaptureExecutionTests(unittest.TestCase):
+    def test_dry_run_does_not_read_token_or_call_client(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            manifest = capture_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                client=ExplodingClient(),
+            )
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "dry-run")
+
+    def test_execute_requires_token_without_client(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "LINODE_TOKEN"):
+                capture_plan(
+                    regions=["us-east"],
+                    run_id="run-test",
+                    ttl="2030-01-01T00:00:00Z",
+                    execute=True,
+                    source_image="linode/debian12",
+                    instance_type="g6-nanode-1",
+                )
+
+    def test_execute_requires_single_region(self) -> None:
+        with self.assertRaisesRegex(CaptureError, "exactly one region"):
+            capture_plan(
+                regions=["us-east", "us-west"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=FakeLinodeClient(),
+            )
+
+    def test_invalid_token_fails_before_mutation(self) -> None:
+        client = InvalidTokenClient()
+
+        with self.assertRaises(CaptureError) as raised:
+            capture_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.calls, ["preflight"])
+        self.assertEqual(raised.exception.manifest["status"], "failed")
+
+    def test_execute_with_fake_client_records_expected_call_order(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                "preflight",
+                "create_instance",
+                "wait_instance_ready",
+                "list_disks",
+                "shutdown_instance",
+                "wait_instance_offline",
+                "capture_image",
+                "wait_image_available",
+                "delete_instance",
+            ],
+        )
+        self.assertEqual(manifest["status"], "succeeded")
+        self.assertEqual(manifest["capture_source"]["linode_id"], 123)
+        self.assertEqual(manifest["custom_image"]["image_id"], "private/789")
+        self.assertEqual(manifest["cleanup"]["status"], "deleted")
+
+    def test_execute_applies_required_tags_to_created_resources(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        expected_tags = manifest["tags"]
+        self.assertEqual(client.create_tags, expected_tags)
+        self.assertEqual(client.image_tags, expected_tags)
+        self.assertIn("mode=capture", expected_tags)
+        self.assertIn("component=capture", expected_tags)
+
+    def test_preserve_source_skips_success_cleanup_delete(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            preserve_source=True,
+            client=client,
+        )
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["status"], "preserved")
+
+    def test_partial_failure_cleanup_skips_resource_missing_required_tags(self) -> None:
+        client = FakeLinodeClient(missing_create_tags=True)
+
+        with self.assertRaises(CaptureError) as raised:
+            capture_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.deleted, [])
+        self.assertIsNotNone(raised.exception.manifest)
+        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "skipped_tag_mismatch")
+
+    def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
+        manifest = capture_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=FakeLinodeClient(),
+        )
+
+        exported = json.loads(serialize_manifest(manifest))
+
+        self.assertEqual(exported["capture_source"]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["capture_source"]["disk_id"], "[REDACTED]")
+        self.assertEqual(exported["custom_image"]["image_id"], "[REDACTED]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -64,6 +64,14 @@ class CliTests(unittest.TestCase):
 
                 self.assertEqual(raised.exception.code, 2)
 
+    def test_capture_execute_requires_options_before_mutation(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["capture", "--region", "us-east", "--execute", "--source-image", "linode/debian12"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--type", error.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+from linode_image_lab.linode_api import LinodeApiError, LinodeClient, LinodeTokenError
+
+TOKEN_VALUE = "test-" + "token-value"
+API_BASE_URL = "https://api.example/v4"
+
+
+class FakeHTTPResponse:
+    def __init__(self, body: dict[str, object] | bytes) -> None:
+        self.body = body
+
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        if isinstance(self.body, bytes):
+            return self.body
+        return json.dumps(self.body).encode("utf-8")
+
+
+def request_payload(request: object) -> dict[str, object]:
+    data = getattr(request, "data")
+    if not isinstance(data, bytes):
+        raise AssertionError("request did not include a JSON body")
+    parsed = json.loads(data.decode("utf-8"))
+    if not isinstance(parsed, dict):
+        raise AssertionError("request body was not a JSON object")
+    return parsed
+
+
+class LinodeClientTests(unittest.TestCase):
+    def test_from_env_missing_token_raises_token_error(self) -> None:
+        with self.assertRaisesRegex(LinodeTokenError, "LINODE_TOKEN"):
+            LinodeClient.from_env({})
+
+    def test_preflight_issues_profile_and_grants_requests(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, timeout_seconds=7)
+        responses = [FakeHTTPResponse({}), FakeHTTPResponse(b"")]
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            self.assertEqual(timeout, 7)
+            return responses.pop(0)
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            client.preflight()
+
+        self.assertEqual([request.get_method() for request in requests], ["GET", "GET"])
+        self.assertEqual(
+            [request.full_url for request in requests],
+            [f"{API_BASE_URL}/profile", f"{API_BASE_URL}/profile/grants"],
+        )
+        self.assertEqual([request.get_header("Authorization") for request in requests], [f"Bearer {TOKEN_VALUE}"] * 2)
+        self.assertEqual(responses, [])
+
+    def test_create_instance_sends_expected_payload_and_maps_response(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        root_value = "generated-" + "root-pass"
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse(
+                {
+                    "id": 123,
+                    "label": "lil-run-source",
+                    "region": "us-east",
+                    "status": "provisioning",
+                    "tags": ["project=linode-image-lab"],
+                }
+            )
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.create_instance(
+                region="us-east",
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                label="lil-run-source",
+                tags=["project=linode-image-lab"],
+                root_password=root_value,
+            )
+
+        self.assertEqual(len(requests), 1)
+        request = requests[0]
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.full_url, f"{API_BASE_URL}/linode/instances")
+        self.assertEqual(
+            request_payload(request),
+            {
+                "booted": True,
+                "image": "linode/debian12",
+                "label": "lil-run-source",
+                "region": "us-east",
+                "root_pass": root_value,
+                "tags": ["project=linode-image-lab"],
+                "type": "g6-nanode-1",
+            },
+        )
+        self.assertEqual(
+            resource,
+            {
+                "linode_id": 123,
+                "label": "lil-run-source",
+                "region": "us-east",
+                "status": "provisioning",
+                "tags": ["project=linode-image-lab"],
+            },
+        )
+
+    def test_capture_image_sends_expected_payload_and_maps_response(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse(
+                {
+                    "id": "private/789",
+                    "label": "lil-run-image",
+                    "status": "creating",
+                    "tags": ["project=linode-image-lab"],
+                }
+            )
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.capture_image(
+                disk_id=456,
+                label="lil-run-image",
+                tags=["project=linode-image-lab"],
+                description="linode-image-lab capture run run-test",
+                cloud_init=True,
+            )
+
+        self.assertEqual(len(requests), 1)
+        request = requests[0]
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.full_url, f"{API_BASE_URL}/images")
+        self.assertEqual(
+            request_payload(request),
+            {
+                "cloud_init": True,
+                "description": "linode-image-lab capture run run-test",
+                "disk_id": 456,
+                "label": "lil-run-image",
+                "tags": ["project=linode-image-lab"],
+            },
+        )
+        self.assertEqual(
+            resource,
+            {
+                "image_id": "private/789",
+                "label": "lil-run-image",
+                "status": "creating",
+                "tags": ["project=linode-image-lab"],
+            },
+        )
+
+    def test_shutdown_instance_uses_expected_path(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse({})
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.shutdown_instance(123)
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].get_method(), "POST")
+        self.assertEqual(requests[0].full_url, f"{API_BASE_URL}/linode/instances/123/shutdown")
+        self.assertEqual(request_payload(requests[0]), {})
+        self.assertEqual(resource, {"linode_id": 123, "action": "shutdown"})
+
+    def test_delete_instance_uses_expected_path(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse({})
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.delete_instance(123)
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].get_method(), "DELETE")
+        self.assertEqual(requests[0].full_url, f"{API_BASE_URL}/linode/instances/123")
+        self.assertIsNone(getattr(requests[0], "data"))
+        self.assertEqual(resource, {"linode_id": 123, "deleted": True})
+
+    def test_auth_failures_map_to_token_error(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        for status in (401, 403):
+            with self.subTest(status=status):
+                with patch(
+                    "linode_image_lab.linode_api.urlopen",
+                    side_effect=HTTPError(f"{API_BASE_URL}/profile", status, "auth failed", {}, None),
+                ):
+                    with self.assertRaises(LinodeTokenError):
+                        client.preflight()
+
+    def test_non_auth_failure_maps_to_api_error_without_token_value(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        with patch(
+            "linode_image_lab.linode_api.urlopen",
+            side_effect=HTTPError(f"{API_BASE_URL}/profile", 500, "server failed", {}, None),
+        ):
+            with self.assertRaises(LinodeApiError) as raised:
+                client.preflight()
+
+        self.assertNotIsInstance(raised.exception, LinodeTokenError)
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
+        self.assertEqual(str(raised.exception), "Linode API request failed with status 500")
+
+    def test_network_failure_maps_to_api_error_without_token_value(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=OSError("network unavailable")):
+            with self.assertRaises(LinodeApiError) as raised:
+                client.preflight()
+
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
+        self.assertEqual(str(raised.exception), "Linode API request failed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -15,6 +15,14 @@ class RedactionTests(unittest.TestCase):
         self.assertEqual(redact_text("Bearer abcdefgh123456"), f"Bearer {REDACTION}")
         self.assertEqual(redact_text("token=abcdefgh123456"), f"token={REDACTION}")
 
+    def test_redacts_provider_identifiers_but_keeps_run_id(self) -> None:
+        payload = {"linode_id": 123, "image_id": "private/123", "run_id": "run-test"}
+
+        self.assertEqual(
+            redact(payload),
+            {"linode_id": REDACTION, "image_id": REDACTION, "run_id": "run-test"},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_redaction.py
+++ b/tests/unit/test_redaction.py
@@ -7,9 +7,9 @@ from linode_image_lab.redaction import REDACTION, redact, redact_text
 
 class RedactionTests(unittest.TestCase):
     def test_redacts_sensitive_mapping_keys(self) -> None:
-        payload = {"token": "not-a-real-value", "env": "LINODE_TOKEN"}
+        payload = {"token": "not-a-real-value", "root_pass": "generated-root-pass", "env": "LINODE_TOKEN"}
 
-        self.assertEqual(redact(payload), {"token": REDACTION, "env": "LINODE_TOKEN"})
+        self.assertEqual(redact(payload), {"token": REDACTION, "root_pass": REDACTION, "env": "LINODE_TOKEN"})
 
     def test_redacts_token_like_text(self) -> None:
         self.assertEqual(redact_text("Bearer abcdefgh123456"), f"Bearer {REDACTION}")


### PR DESCRIPTION
## Summary

Implements M2 single-region capture behind an explicit `capture --execute` opt-in while preserving the default non-mutating dry-run behavior.

## Implementation scope

This is a contract-first implementation with a small real Linode HTTP client boundary:

- adds `capture --execute` CLI options for one-region capture execution
- enforces the token boundary so dry-run does not read `LINODE_TOKEN`
- adds a mockable Linode client interface plus HTTP implementation
- orchestrates preflight, temporary source creation, readiness checks, tag/region validation, shutdown, custom image capture, image readiness, and source cleanup/preservation
- extends execute manifests with `execution_mode`, `steps`, `resources`, `capture_source`, `custom_image`, and `cleanup`
- redacts provider resource identifiers from normal serialized output
- updates M2 docs and repo-local guidance

Deploy, capture-deploy, multi-region execution, scheduler integration, and live Linode calls in CI remain out of scope.

## Validation

- `make check` passed
- `make security-check` passed
- CLI smoke: dry-run capture emits non-mutating JSON
- CLI smoke: `capture --execute` without `LINODE_TOKEN` fails before mutation

## Residual risks

- Live Linode behavior is covered through fake-client contract tests, not live CI calls.
- Linode account permission/tagging behavior may vary by account; execution fails safely if required tags cannot be verified.
- The custom image is preserved by default after successful capture; image deletion remains a manual follow-up for M2.
