### PR TITLE
[codex] M3 single-region deploy execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,10 @@ Repo-local rules take precedence only for repo-specific behavior.
   manifest modeling, tag contracts, cleanup selection logic, docs, and tests.
 - M2 permits explicit single-region capture execution only through
   `capture --execute`; default behavior remains non-mutating.
-- Do not add deploy, capture-deploy, multi-region execution, or additional real
-  Linode mutation behavior until a later milestone explicitly asks for it.
+- M3 permits explicit single-region deploy execution only through
+  `deploy --execute`; default behavior remains non-mutating.
+- Do not add capture-deploy, multi-region execution, or additional real Linode
+  mutation behavior until a later milestone explicitly asks for it.
 
 ## Public-Safe Boundary
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 Linode Image Lab is a small Python scaffold for modeling and safely exercising
 custom image capture/deploy workflows.
 
-M2 remains intentionally conservative:
+M3 remains intentionally conservative:
 
 - `plan` emits a dry-run, sanitized manifest-like preview.
 - `capture` is dry-run by default.
-- `capture --execute` is the only command that can mutate Linode resources.
-- `deploy` and `capture-deploy` remain explicit placeholders.
+- `deploy` is dry-run by default.
+- `capture --execute` and `deploy --execute` are the only commands that can
+  mutate Linode resources.
+- `capture-deploy` remains an explicit placeholder.
 - `cleanup` is first-class and independently runnable.
 - Manifest schema, rediscoverable tags, and cleanup selection are the foundation.
 
@@ -27,8 +29,8 @@ make check
 PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east --run-id demo-run
 ```
 
-`LINODE_TOKEN` is read only when `capture --execute` is used. Dry-run commands
-do not read the token, call Linode, or mutate resources.
+`LINODE_TOKEN` is read only when `capture --execute` or `deploy --execute` is
+used. Dry-run commands do not read the token, call Linode, or mutate resources.
 
 ## Required Tags
 
@@ -47,6 +49,7 @@ PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east,us-west
 PYTHONPATH=src python3 -m linode_image_lab.cli capture --region us-east
 PYTHONPATH=src python3 -m linode_image_lab.cli capture --region us-east --execute --source-image linode/debian12 --type g6-nanode-1
 PYTHONPATH=src python3 -m linode_image_lab.cli deploy --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli deploy --region us-east --execute --image-id "$CUSTOM_IMAGE_ID" --type g6-nanode-1
 PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy --region us-east
 PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
 ```
@@ -55,6 +58,13 @@ PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
 `LINODE_TOKEN`. It creates a temporary capture-source Linode, waits for it to be
 ready, powers it off, captures a custom image from its disk, waits for the image,
 then deletes the temporary source unless `--preserve-source` is provided.
+
+`deploy --execute` requires exactly one region, `--image-id`, `--type`, and
+`LINODE_TOKEN`. `--image-id` is the existing custom image to boot from. The
+command creates a temporary deploy Linode, waits for provider/API-level running
+status, validates the requested region and required tags, then deletes the
+temporary instance unless `--preserve-instance` is provided. M3 does not perform
+SSH, cloud-init, service, or application readiness validation.
 
 Normal stdout is a redacted, export-safe manifest view. Local in-memory
 manifests may retain provider identifiers needed for cleanup and debugging, but

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -1,8 +1,8 @@
 # Capture-Deploy Workflow
 
 This document describes the current capture/deploy workflow shape. M2 adds
-single-region capture execution only; deploy and capture-deploy execution remain
-out of scope.
+single-region capture execution, M3 adds single-region deploy execution, and
+capture-deploy execution remains out of scope.
 
 ## Capture
 
@@ -33,8 +33,42 @@ The custom image is preserved by default because it is the capture deliverable.
 
 ## Deploy
 
-The deploy flow creates a new Linode from a custom image. The command currently
-returns a placeholder manifest and performs no Linode action.
+The deploy flow creates a temporary Linode from a custom image. By default, the
+command returns a dry-run manifest and performs no Linode action.
+
+`deploy --execute` is the only mutating deploy command. It creates a temporary
+Linode from the existing custom image passed as `--image-id` and may incur
+account charges until cleanup completes. It requires:
+
+- exactly one `--region`,
+- `--image-id`,
+- `--type`,
+- `LINODE_TOKEN`.
+
+Execution steps:
+
+1. preflight token access without mutating resources,
+2. create a temporary deploy Linode from the custom image id,
+3. wait until the provider reports the instance is running,
+4. validate provider/API-level running status, requested region, and required tags,
+5. delete the temporary instance unless `--preserve-instance` is set.
+
+The deploy instance is deleted by default because deploy execution is a quick
+validation path, not a long-lived server creation flow.
+
+M3 deploy validation stops at provider/API-level instance creation. It does not
+perform SSH, cloud-init, service, or application readiness checks.
+
+Live smoke command shape:
+
+```sh
+LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli deploy \
+  --region us-east \
+  --execute \
+  --image-id "$CUSTOM_IMAGE_ID" \
+  --type g6-nanode-1 \
+  --run-id "run-m3-smoke"
+```
 
 ## Capture-Deploy
 
@@ -54,7 +88,9 @@ required tags are present:
 - `component=<capture|deploy>`
 - `ttl=<timestamp>`
 
-Execute-mode capture cleanup is narrower than general cleanup. It only attempts
-to delete the current run's temporary capture-source Linode, and only when that
-resource has all required tags matching the current run. If tags are missing or
-do not match, cleanup is skipped and the manifest reports the skip.
+Execute-mode cleanup is narrower than general cleanup. Capture only attempts to
+delete the current run's temporary capture-source Linode, and deploy only
+attempts to delete the current run's temporary deploy Linode. In both cases,
+cleanup proceeds only when the resource has all required tags matching the
+current run. If tags are missing or do not match, cleanup is skipped and the
+manifest reports the skip.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -26,6 +26,7 @@ Before opening a PR:
 - run `make check`,
 - confirm fixtures are sanitized,
 - confirm dry-run commands remain non-mutating,
-- confirm real mutation remains limited to explicit `capture --execute`,
+- confirm real mutation remains limited to explicit `capture --execute` and
+  `deploy --execute`,
 - confirm cleanup only targets resources with complete matching tags,
 - confirm docs describe behavior without private context.

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,19 +9,20 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 - Create sanitized manifest previews for dry-run planning.
 - Define a stable tag contract for resource rediscovery.
 - Make cleanup selection testable without cloud access.
-- Allow single-region capture execution only after explicit opt-in.
+- Allow single-region capture and deploy execution only after explicit opt-in.
 
 ## Non-Goals
 
 - No implicit Linode API mutations.
-- No deploy execution, capture-deploy execution, multi-region execution,
-  GitHub Actions mutation, or external scheduler integration.
+- No capture-deploy execution, multi-region execution, GitHub Actions mutation,
+  or external scheduler integration.
 - CI exists to run `make check`.
 
 ## Components
 
 - `cli.py` owns command parsing and JSON output.
 - `capture.py` owns dry-run capture manifests and execute-mode orchestration.
+- `deploy.py` owns dry-run deploy manifests and execute-mode orchestration.
 - `manifest.py` owns manifest creation, tag generation, and sanitized
   serialization.
 - `regions.py` owns one-or-many region parsing.
@@ -37,7 +38,9 @@ actions. Future milestones can add fields while preserving the required tag
 contract.
 
 M2 capture execution adds `execution_mode`, ordered `steps`, `resources`,
-`capture_source`, `custom_image`, and `cleanup` fields. Internal manifests may
+`capture_source`, `custom_image`, and `cleanup` fields. M3 deploy execution adds
+`execution_mode`, ordered `steps`, `resources`, `deploy_source`,
+`deploy_instance`, `validation`, and `cleanup` fields. Internal manifests may
 carry provider resource identifiers required for cleanup and debugging. Normal
 stdout uses sanitized serialization, which redacts provider identifiers before
 printing.
@@ -58,3 +61,20 @@ The execute flow is intentionally linear:
 6. capture a custom image from the selected disk,
 7. wait for image availability,
 8. delete or preserve the source according to explicit flags.
+
+## Deploy Execution Boundary
+
+`deploy` without `--execute` remains non-mutating and does not read
+`LINODE_TOKEN`. `deploy --execute` requires exactly one region, an existing
+custom image id via `--image-id`, a Linode type, and `LINODE_TOKEN`.
+
+The execute flow is intentionally linear:
+
+1. preflight the token with non-mutating API calls,
+2. create a tagged temporary deploy Linode from the custom image id,
+3. wait for provider/API-level running status,
+4. validate running status, requested region, and required tags,
+5. delete or preserve the deploy instance according to explicit flags.
+
+M3 does not perform SSH, cloud-init, service, or application readiness
+validation.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,13 +1,14 @@
 # Security
 
 Linode Image Lab is designed to be public-safe by default. Dry-run behavior is
-non-mutating; M2 capture execution requires explicit opt-in.
+non-mutating; capture and deploy execution require explicit opt-in.
 
 ## Token Handling
 
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
-- The CLI reads `LINODE_TOKEN` only for `capture --execute`.
+- The CLI reads `LINODE_TOKEN` only for `capture --execute` and
+  `deploy --execute`.
 - Dry-run commands do not read token values.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
 - Normal stdout and stderr must not print tokens, authorization headers, root
@@ -15,8 +16,8 @@ non-mutating; M2 capture execution requires explicit opt-in.
 
 ## Execute Permissions
 
-`capture --execute` needs a personal access token or equivalent OAuth access
-that can:
+`capture --execute` and `deploy --execute` need a personal access token or
+equivalent OAuth access that can:
 
 - read the current profile for preflight,
 - create, read, shut down, and delete temporary Linodes,
@@ -25,8 +26,10 @@ that can:
 
 In Linode scope terms, this generally means `linodes:read_write` and
 `images:read_write`, plus account permissions or grants that allow Linode
-creation and tagging. If tags cannot be applied or later verified, execution
-fails safely because cleanup depends on rediscoverable tags.
+creation and tagging. Deploy execution from an existing image does not create a
+custom image, but the same image read permissions are expected. If tags cannot
+be applied or later verified, execution fails safely because cleanup depends on
+rediscoverable tags.
 
 ## Public-Safety Scan
 
@@ -45,12 +48,12 @@ loss prevention system.
 
 ## Mutation Safety
 
-`plan` is dry-run only. `capture` is dry-run unless `--execute` is provided.
-`deploy` and `capture-deploy` return explicit placeholder responses. `cleanup`
-currently selects candidates from provided data structures and does not call
-Linode.
+`plan` is dry-run only. `capture` and `deploy` are dry-run unless `--execute`
+is provided. `capture-deploy` returns an explicit placeholder response.
+`cleanup` currently selects candidates from provided data structures and does
+not call Linode.
 
-`capture --execute` fails before mutation if required options or `LINODE_TOKEN`
-are missing. It performs non-mutating token preflight before creating resources.
-Partial-failure cleanup only targets resources whose required tags exactly
-match the current run.
+`capture --execute` and `deploy --execute` fail before mutation if required
+options or `LINODE_TOKEN` are missing. They perform non-mutating token preflight
+before creating resources. Partial-failure cleanup only targets resources whose
+required tags exactly match the current run.

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from .cleanup import select_cleanup_candidates
 from .capture import CaptureError, capture_plan
-from .deploy import deploy_plan
+from .deploy import DeployError, deploy_plan
 from .manifest import create_manifest, serialize_manifest
 from .regions import parse_regions
 
@@ -49,8 +49,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep the temporary capture-source Linode after execution.",
     )
 
-    deploy = subparsers.add_parser("deploy", help="Placeholder deploy command.")
+    deploy = subparsers.add_parser("deploy", help="Plan or execute a single-region deploy.")
     add_region_args(deploy, required=True)
+    deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    deploy.add_argument("--image-id", help="Custom image id for the temporary deploy Linode.")
+    deploy.add_argument("--type", dest="instance_type", help="Linode type for the temporary deploy Linode.")
+    deploy.add_argument(
+        "--preserve-instance",
+        action="store_true",
+        help="Keep the temporary deploy Linode after execution.",
+    )
 
     capture_deploy = subparsers.add_parser("capture-deploy", help="Placeholder combined command.")
     add_region_args(capture_deploy, required=True)
@@ -87,7 +95,15 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     if args.command == "deploy":
-        return deploy_plan(regions=parse_regions(args.region), run_id=args.run_id, ttl=args.ttl)
+        return deploy_plan(
+            regions=parse_regions(args.region),
+            run_id=args.run_id,
+            ttl=args.ttl,
+            execute=args.execute,
+            image_id=args.image_id,
+            instance_type=args.instance_type,
+            preserve_instance=args.preserve_instance,
+        )
 
     if args.command == "capture-deploy":
         manifest = create_manifest(
@@ -128,6 +144,12 @@ def main(argv: list[str] | None = None) -> int:
         if exc.manifest is not None:
             sys.stdout.write(serialize_manifest(exc.manifest))
             sys.stderr.write("capture --execute failed\n")
+            return 1
+        parser.error(str(exc))
+    except DeployError as exc:
+        if exc.manifest is not None:
+            sys.stdout.write(serialize_manifest(exc.manifest))
+            sys.stderr.write("deploy --execute failed\n")
             return 1
         parser.error(str(exc))
     except ValueError as exc:

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -1,21 +1,274 @@
-"""Deploy command placeholder."""
+"""Deploy command planning and execution orchestration."""
 
 from __future__ import annotations
 
+import re
+import secrets
+from dataclasses import dataclass
 from typing import Any
 
-from .manifest import create_manifest
+from .linode_api import LinodeClient, LinodeClientProtocol
+from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
 
 
-def deploy_plan(*, regions: list[str], run_id: str | None = None, ttl: str | None = None) -> dict[str, Any]:
-    manifest = create_manifest(
-        command="deploy",
-        mode="deploy",
+class DeployError(ValueError):
+    """Raised when deploy cannot safely complete."""
+
+    def __init__(self, message: str, manifest: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.manifest = manifest
+
+
+@dataclass(frozen=True)
+class DeployOptions:
+    regions: list[str]
+    run_id: str | None = None
+    ttl: str | None = None
+    execute: bool = False
+    image_id: str | None = None
+    instance_type: str | None = None
+    preserve_instance: bool = False
+
+
+def deploy_plan(
+    *,
+    regions: list[str],
+    run_id: str | None = None,
+    ttl: str | None = None,
+    execute: bool = False,
+    image_id: str | None = None,
+    instance_type: str | None = None,
+    preserve_instance: bool = False,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    options = DeployOptions(
         regions=regions,
         run_id=run_id,
         ttl=ttl,
-        dry_run=True,
-        status="placeholder",
+        execute=execute,
+        image_id=image_id,
+        instance_type=instance_type,
+        preserve_instance=preserve_instance,
     )
-    manifest["message"] = "deploy is a non-mutating placeholder"
+    if not execute:
+        return dry_run_manifest(options)
+    return execute_deploy(options, client=client)
+
+
+def dry_run_manifest(options: DeployOptions) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="deploy",
+        mode="deploy",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=True,
+        status="planned",
+    )
+    manifest["execution_mode"] = "dry-run"
+    manifest["message"] = "deploy is non-mutating unless --execute is provided"
     return manifest
+
+
+def execute_deploy(
+    options: DeployOptions,
+    *,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    validate_execute_options(options)
+    manifest = create_manifest(
+        command="deploy",
+        mode="deploy",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=False,
+        status="running",
+    )
+    manifest["execution_mode"] = "execute"
+    manifest["steps"] = []
+    manifest["resources"] = []
+    manifest["deploy_source"] = {"image_id": required_text(options.image_id)}
+    manifest["deploy_instance"] = {}
+    manifest["validation"] = {"status": "not_started", "checks": []}
+    manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+    for action in manifest["planned_actions"]:
+        action["mutates"] = True
+
+    run_client = client or LinodeClient.from_env(command="deploy")
+    deploy_instance: dict[str, Any] | None = None
+
+    try:
+        append_step(manifest, "preflight", mutates=False, status="running")
+        run_client.preflight()
+        finish_step(manifest, "preflight")
+
+        tags = list(manifest["tags"])
+        region = options.regions[0]
+        instance_label = f"lil-{safe_label_suffix(manifest['run_id'])}-deploy"
+
+        append_step(manifest, "create_deploy_instance", mutates=True, status="running")
+        deploy_instance = run_client.create_instance(
+            region=region,
+            source_image=required_text(options.image_id),
+            instance_type=required_text(options.instance_type),
+            label=instance_label,
+            tags=tags,
+            root_password=secrets.token_urlsafe(32),
+        )
+        deploy_instance["resource_type"] = "linode"
+        manifest["deploy_instance"] = dict(deploy_instance)
+        manifest["resources"].append(dict(deploy_instance))
+        finish_step(manifest, "create_deploy_instance")
+
+        append_step(manifest, "wait_deploy_instance_ready", mutates=False, status="running")
+        deploy_instance = merge_resource(
+            deploy_instance,
+            run_client.wait_instance_ready(required_int(deploy_instance.get("linode_id"))),
+        )
+        manifest["deploy_instance"] = dict(deploy_instance)
+        manifest["resources"][0] = dict(deploy_instance)
+        finish_step(manifest, "wait_deploy_instance_ready")
+
+        append_step(manifest, "validate_deploy_instance", mutates=False, status="running")
+        validate_deploy_instance(deploy_instance, required_tags=tags, region=region)
+        manifest["validation"] = {
+            "status": "succeeded",
+            "checks": [
+                "instance_running",
+                "region_matches",
+                "required_tags_match",
+            ],
+        }
+        finish_step(manifest, "validate_deploy_instance")
+
+        cleanup_deploy_instance(
+            manifest,
+            run_client,
+            deploy_instance=deploy_instance,
+            preserve_instance=options.preserve_instance,
+            required_tags=tags,
+        )
+        manifest["status"] = "succeeded"
+        return manifest
+    except Exception as exc:
+        mark_running_step_failed(manifest)
+        manifest["status"] = "failed"
+        manifest["errors"] = [safe_error_message(exc)]
+        if deploy_instance is not None and not cleanup_started(manifest):
+            try:
+                cleanup_deploy_instance(
+                    manifest,
+                    run_client,
+                    deploy_instance=deploy_instance,
+                    preserve_instance=options.preserve_instance,
+                    required_tags=list(manifest["tags"]),
+                )
+            except Exception:
+                mark_running_step_failed(manifest)
+                manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+        raise DeployError("deploy --execute failed", manifest) from exc
+
+
+def validate_execute_options(options: DeployOptions) -> None:
+    if len(options.regions) != 1:
+        raise DeployError("deploy --execute requires exactly one region")
+    if not options.image_id:
+        raise DeployError("deploy --execute requires --image-id")
+    if not options.instance_type:
+        raise DeployError("deploy --execute requires --type")
+
+
+def cleanup_deploy_instance(
+    manifest: dict[str, Any],
+    client: LinodeClientProtocol,
+    *,
+    deploy_instance: dict[str, Any],
+    preserve_instance: bool,
+    required_tags: list[str],
+) -> None:
+    append_step(manifest, "cleanup_deploy_instance", mutates=not preserve_instance, status="running")
+    cleanup = {"status": "not_started", "deleted": [], "preserved": []}
+    if preserve_instance:
+        cleanup["status"] = "preserved"
+        cleanup["preserved"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
+    elif has_required_tags(deploy_instance, required_tags):
+        client.delete_instance(required_int(deploy_instance.get("linode_id")))
+        cleanup["status"] = "deleted"
+        cleanup["deleted"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
+    else:
+        cleanup["status"] = "skipped_tag_mismatch"
+        cleanup["preserved"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
+    manifest["cleanup"] = cleanup
+    finish_step(manifest, "cleanup_deploy_instance")
+
+
+def append_step(manifest: dict[str, Any], name: str, *, mutates: bool, status: str) -> None:
+    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+
+
+def finish_step(manifest: dict[str, Any], name: str) -> None:
+    for step in reversed(manifest["steps"]):
+        if step["name"] == name:
+            step["status"] = "succeeded"
+            return
+
+
+def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+    for step in reversed(manifest.get("steps", [])):
+        if step.get("status") == "running":
+            step["status"] = "failed"
+            return
+
+
+def cleanup_started(manifest: dict[str, Any]) -> bool:
+    return any(step.get("name") == "cleanup_deploy_instance" for step in manifest.get("steps", []))
+
+
+def validate_deploy_instance(
+    resource: dict[str, Any],
+    *,
+    required_tags: list[str],
+    region: str,
+) -> None:
+    if resource.get("region") != region:
+        raise DeployError("created deploy instance is not in the requested region")
+    if resource.get("status") != "running":
+        raise DeployError("created deploy instance is not running")
+    if not has_required_tags(resource, required_tags):
+        raise DeployError("created resource is missing required deploy tags")
+
+
+def has_required_tags(resource: dict[str, Any], required_tags: list[str]) -> bool:
+    tags = tags_to_dict(resource.get("tags", []))
+    expected = tags_to_dict(required_tags)
+    return all(key in tags and tags[key] == expected[key] for key in REQUIRED_TAG_KEYS)
+
+
+def merge_resource(current: dict[str, Any], update: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(current)
+    merged.update({key: value for key, value in update.items() if value is not None})
+    return merged
+
+
+def required_text(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise DeployError("required deploy value is missing")
+    return value
+
+
+def required_int(value: object) -> int:
+    if not isinstance(value, int):
+        raise DeployError("required provider resource id is missing")
+    return value
+
+
+def safe_label_suffix(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
+    return (normalized or "run")[:32]
+
+
+def safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, DeployError):
+        return str(exc)
+    return exc.__class__.__name__

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -1,4 +1,4 @@
-"""Linode API boundary for capture execution."""
+"""Linode API boundary for explicit execution commands."""
 
 from __future__ import annotations
 
@@ -71,11 +71,11 @@ class LinodeClient:
     max_wait_seconds: float = 900
 
     @classmethod
-    def from_env(cls, env: dict[str, str] | None = None) -> "LinodeClient":
+    def from_env(cls, env: dict[str, str] | None = None, *, command: str = "capture") -> "LinodeClient":
         values = env if env is not None else os.environ
         token = values.get(TOKEN_ENV_NAME)
         if not token:
-            raise LinodeTokenError(f"{TOKEN_ENV_NAME} is required for capture --execute")
+            raise LinodeTokenError(f"{TOKEN_ENV_NAME} is required for {command} --execute")
         return cls(token=token)
 
     def preflight(self) -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,6 +72,14 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--type", error.getvalue())
 
+    def test_deploy_execute_requires_options_before_mutation(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["deploy", "--region", "us-east", "--execute", "--image-id", "private/789"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--type", error.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from linode_image_lab.deploy import DeployError, deploy_plan
+from linode_image_lab.linode_api import LinodeTokenError
+from linode_image_lab.manifest import serialize_manifest
+
+
+class FakeLinodeClient:
+    def __init__(self, *, missing_create_tags: bool = False, status: str = "running") -> None:
+        self.calls: list[str] = []
+        self.create_tags: list[str] = []
+        self.deleted: list[int] = []
+        self.missing_create_tags = missing_create_tags
+        self.status = status
+
+    def preflight(self) -> None:
+        self.calls.append("preflight")
+
+    def create_instance(
+        self,
+        *,
+        region: str,
+        source_image: str,
+        instance_type: str,
+        label: str,
+        tags: list[str],
+        root_password: str,
+    ) -> dict[str, object]:
+        self.calls.append("create_instance")
+        self.create_tags = tags
+        self.source_image = source_image
+        self.instance_type = instance_type
+        self.root_password_length = len(root_password)
+        return {
+            "linode_id": 321,
+            "label": label,
+            "region": region,
+            "status": "provisioning",
+            "tags": [] if self.missing_create_tags else tags,
+        }
+
+    def wait_instance_ready(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("wait_instance_ready")
+        return {
+            "linode_id": linode_id,
+            "region": "us-east",
+            "status": self.status,
+            "tags": [] if self.missing_create_tags else self.create_tags,
+        }
+
+    def list_disks(self, linode_id: int) -> list[dict[str, object]]:
+        raise AssertionError("deploy must not inspect disks")
+
+    def shutdown_instance(self, linode_id: int) -> dict[str, object]:
+        raise AssertionError("deploy must not shut down the instance")
+
+    def wait_instance_offline(self, linode_id: int) -> dict[str, object]:
+        raise AssertionError("deploy must not wait for offline status")
+
+    def capture_image(
+        self,
+        *,
+        disk_id: int,
+        label: str,
+        tags: list[str],
+        description: str,
+        cloud_init: bool,
+    ) -> dict[str, object]:
+        raise AssertionError("deploy must not capture an image")
+
+    def wait_image_available(self, image_id: str) -> dict[str, object]:
+        raise AssertionError("deploy must not wait on image availability")
+
+    def delete_instance(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("delete_instance")
+        self.deleted.append(linode_id)
+        return {"linode_id": linode_id, "deleted": True}
+
+
+class ExplodingClient:
+    def preflight(self) -> None:
+        raise AssertionError("dry-run must not call the client")
+
+
+class InvalidTokenClient(FakeLinodeClient):
+    def preflight(self) -> None:
+        self.calls.append("preflight")
+        raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
+
+
+class DeployExecutionTests(unittest.TestCase):
+    def test_dry_run_does_not_read_token_or_call_client(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            manifest = deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                client=ExplodingClient(),
+            )
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "dry-run")
+
+    def test_execute_requires_token_without_client(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "LINODE_TOKEN"):
+                deploy_plan(
+                    regions=["us-east"],
+                    run_id="run-test",
+                    ttl="2030-01-01T00:00:00Z",
+                    execute=True,
+                    image_id="private/789",
+                    instance_type="g6-nanode-1",
+                )
+
+    def test_execute_requires_single_region(self) -> None:
+        with self.assertRaisesRegex(DeployError, "exactly one region"):
+            deploy_plan(
+                regions=["us-east", "us-west"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                image_id="private/789",
+                instance_type="g6-nanode-1",
+                client=FakeLinodeClient(),
+            )
+
+    def test_execute_requires_image_id(self) -> None:
+        with self.assertRaisesRegex(DeployError, "--image-id"):
+            deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                instance_type="g6-nanode-1",
+                client=FakeLinodeClient(),
+            )
+
+    def test_execute_requires_type(self) -> None:
+        with self.assertRaisesRegex(DeployError, "--type"):
+            deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                image_id="private/789",
+                client=FakeLinodeClient(),
+            )
+
+    def test_invalid_token_fails_before_mutation(self) -> None:
+        client = InvalidTokenClient()
+
+        with self.assertRaises(DeployError) as raised:
+            deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                image_id="private/789",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.calls, ["preflight"])
+        self.assertEqual(raised.exception.manifest["status"], "failed")
+
+    def test_execute_with_fake_client_records_expected_call_order(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            image_id="private/789",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                "preflight",
+                "create_instance",
+                "wait_instance_ready",
+                "delete_instance",
+            ],
+        )
+        self.assertEqual(manifest["status"], "succeeded")
+        self.assertEqual(manifest["deploy_instance"]["linode_id"], 321)
+        self.assertEqual(manifest["validation"]["status"], "succeeded")
+        self.assertEqual(manifest["cleanup"]["status"], "deleted")
+
+    def test_execute_applies_required_tags_to_created_resource(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            image_id="private/789",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        expected_tags = manifest["tags"]
+        self.assertEqual(client.create_tags, expected_tags)
+        self.assertIn("mode=deploy", expected_tags)
+        self.assertIn("component=deploy", expected_tags)
+
+    def test_preserve_instance_skips_success_cleanup_delete(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            image_id="private/789",
+            instance_type="g6-nanode-1",
+            preserve_instance=True,
+            client=client,
+        )
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["status"], "preserved")
+
+    def test_partial_failure_cleanup_skips_resource_missing_required_tags(self) -> None:
+        client = FakeLinodeClient(missing_create_tags=True)
+
+        with self.assertRaises(DeployError) as raised:
+            deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                image_id="private/789",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.deleted, [])
+        self.assertIsNotNone(raised.exception.manifest)
+        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "skipped_tag_mismatch")
+
+    def test_partial_failure_deletes_tagged_resource_by_default(self) -> None:
+        client = FakeLinodeClient(status="offline")
+
+        with self.assertRaises(DeployError) as raised:
+            deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                image_id="private/789",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.deleted, [321])
+        self.assertIsNotNone(raised.exception.manifest)
+        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "deleted")
+
+    def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
+        manifest = deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            image_id="private/789",
+            instance_type="g6-nanode-1",
+            client=FakeLinodeClient(),
+        )
+
+        exported = json.loads(serialize_manifest(manifest))
+
+        self.assertEqual(exported["deploy_source"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy_instance"]["linode_id"], "[REDACTED]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -38,6 +38,11 @@ def request_payload(request: object) -> dict[str, object]:
 
 
 class LinodeClientTests(unittest.TestCase):
+    def http_error(self, status: int, message: str) -> HTTPError:
+        error = HTTPError(f"{API_BASE_URL}/profile", status, message, {}, None)
+        self.addCleanup(error.close)
+        return error
+
     def test_from_env_missing_token_raises_token_error(self) -> None:
         with self.assertRaisesRegex(LinodeTokenError, "LINODE_TOKEN"):
             LinodeClient.from_env({})
@@ -199,14 +204,59 @@ class LinodeClientTests(unittest.TestCase):
         self.assertIsNone(getattr(requests[0], "data"))
         self.assertEqual(resource, {"linode_id": 123, "deleted": True})
 
+    def test_wait_instance_ready_polls_until_running(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            poll_interval_seconds=0,
+            max_wait_seconds=1,
+        )
+        responses = [
+            FakeHTTPResponse(
+                {
+                    "id": 123,
+                    "label": "lil-run-deploy",
+                    "region": "us-east",
+                    "status": "provisioning",
+                    "tags": ["project=linode-image-lab"],
+                }
+            ),
+            FakeHTTPResponse(
+                {
+                    "id": 123,
+                    "label": "lil-run-deploy",
+                    "region": "us-east",
+                    "status": "running",
+                    "tags": ["project=linode-image-lab"],
+                }
+            ),
+        ]
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return responses.pop(0)
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.wait_instance_ready(123)
+
+        self.assertEqual([request.get_method() for request in requests], ["GET", "GET"])
+        self.assertEqual(
+            [request.full_url for request in requests],
+            [f"{API_BASE_URL}/linode/instances/123", f"{API_BASE_URL}/linode/instances/123"],
+        )
+        self.assertEqual(resource["status"], "running")
+        self.assertEqual(responses, [])
+
     def test_auth_failures_map_to_token_error(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
 
         for status in (401, 403):
             with self.subTest(status=status):
+                error = self.http_error(status, "auth failed")
                 with patch(
                     "linode_image_lab.linode_api.urlopen",
-                    side_effect=HTTPError(f"{API_BASE_URL}/profile", status, "auth failed", {}, None),
+                    side_effect=error,
                 ):
                     with self.assertRaises(LinodeTokenError):
                         client.preflight()
@@ -216,7 +266,7 @@ class LinodeClientTests(unittest.TestCase):
 
         with patch(
             "linode_image_lab.linode_api.urlopen",
-            side_effect=HTTPError(f"{API_BASE_URL}/profile", 500, "server failed", {}, None),
+            side_effect=self.http_error(500, "server failed"),
         ):
             with self.assertRaises(LinodeApiError) as raised:
                 client.preflight()


### PR DESCRIPTION
## Summary
- Adds explicit single-region `deploy --execute` using a custom image id, with dry-run remaining the default.
- Adds deploy execute manifest fields, required deploy tags, provider/API-level validation, default cleanup, and `--preserve-instance`.
- Polishes PR nits by closing mocked HTTPError objects to remove ResourceWarning noise and clarifying that M3 deploy validation stops at provider/API-level instance creation, running status, region, and tags.

## Validation
- `make check` passed: security-check passed; 52 unit tests passed with no ResourceWarning output.
- `make security-check` passed.

## Live API Calls
- No live Linode API calls were made. Tests use fake clients and mocked HTTP responses only.

## Residual Risks
- M3 does not perform SSH, cloud-init, service, or application readiness validation.
- Preserved deploy instances remain intentionally inspectable only through provider-side controls and required tags; normal stdout/stderr still redacts provider identifiers.