### PR TITLE
[codex] Implement m4 capture-deploy validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 Linode Image Lab is a small Python scaffold for modeling and safely exercising
 custom image capture/deploy workflows.
 
-M3 remains intentionally conservative:
+M4 remains intentionally conservative:
 
 - `plan` emits a dry-run, sanitized manifest-like preview.
 - `capture` is dry-run by default.
 - `deploy` is dry-run by default.
-- `capture --execute` and `deploy --execute` are the only commands that can
-  mutate Linode resources.
-- `capture-deploy` remains an explicit placeholder.
+- `capture-deploy` is dry-run by default.
+- `capture --execute`, `deploy --execute`, and `capture-deploy --execute` are
+  the only commands that can mutate Linode resources.
 - `cleanup` is first-class and independently runnable.
 - Manifest schema, rediscoverable tags, and cleanup selection are the foundation.
 
@@ -29,8 +29,9 @@ make check
 PYTHONPATH=src python3 -m linode_image_lab.cli plan --region us-east --run-id demo-run
 ```
 
-`LINODE_TOKEN` is read only when `capture --execute` or `deploy --execute` is
-used. Dry-run commands do not read the token, call Linode, or mutate resources.
+`LINODE_TOKEN` is read only when `capture --execute`, `deploy --execute`, or
+`capture-deploy --execute` is used. Dry-run commands do not read the token, call
+Linode, or mutate resources.
 
 ## Required Tags
 
@@ -51,6 +52,7 @@ PYTHONPATH=src python3 -m linode_image_lab.cli capture --region us-east --execut
 PYTHONPATH=src python3 -m linode_image_lab.cli deploy --region us-east
 PYTHONPATH=src python3 -m linode_image_lab.cli deploy --region us-east --execute --image-id "$CUSTOM_IMAGE_ID" --type g6-nanode-1
 PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy --region us-east
+PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy --region us-east --execute --source-image linode/debian12 --type g6-nanode-1
 PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
 ```
 
@@ -63,8 +65,15 @@ then deletes the temporary source unless `--preserve-source` is provided.
 `LINODE_TOKEN`. `--image-id` is the existing custom image to boot from. The
 command creates a temporary deploy Linode, waits for provider/API-level running
 status, validates the requested region and required tags, then deletes the
-temporary instance unless `--preserve-instance` is provided. M3 does not perform
-SSH, cloud-init, service, or application readiness validation.
+temporary instance unless `--preserve-instance` is provided. Deploy validation
+does not perform SSH, cloud-init, service, or application readiness validation.
+
+`capture-deploy --execute` requires exactly one region, `--source-image`,
+`--type`, and `LINODE_TOKEN`. It captures a custom image, deploys a temporary
+validation Linode from that image, validates provider/API-level running status,
+requested region, and required tags, then deletes the temporary capture-source
+and deploy validation Linodes. The custom image is preserved by default as the
+deliverable. `--preserve-instance` keeps only the deploy validation Linode.
 
 Normal stdout is a redacted, export-safe manifest view. Local in-memory
 manifests may retain provider identifiers needed for cleanup and debugging, but

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -1,8 +1,8 @@
 # Capture-Deploy Workflow
 
 This document describes the current capture/deploy workflow shape. M2 adds
-single-region capture execution, M3 adds single-region deploy execution, and
-capture-deploy execution remains out of scope.
+single-region capture execution, M3 adds single-region deploy execution, and M4
+adds single-region capture-deploy execution.
 
 ## Capture
 
@@ -73,8 +73,40 @@ LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli depl
 ## Capture-Deploy
 
 The capture-deploy flow validates the end-to-end path by capturing a custom
-image, then deploying a new Linode from it. The command currently returns a
-placeholder manifest with `mode=capture-deploy`.
+image, then deploying a new Linode from it. By default, the command returns a
+dry-run manifest and performs no Linode action.
+
+`capture-deploy --execute` is the only mutating combined command. It requires:
+
+- exactly one `--region`,
+- `--source-image`,
+- `--type`,
+- `LINODE_TOKEN`.
+
+Execution steps:
+
+1. run capture execution with `mode=capture-deploy` and `component=capture`,
+2. retain the internal custom image id in memory,
+3. run deploy execution with `mode=capture-deploy` and `component=deploy`,
+4. validate provider/API-level running status, requested region, and required tags,
+5. delete the temporary capture-source Linode,
+6. delete the temporary deploy validation Linode unless `--preserve-instance` is set,
+7. preserve the custom image as the workflow deliverable.
+
+The internal image id is passed directly from capture to deploy. Normal stdout
+redacts provider identifiers, so the image id is not exposed in serialized
+manifests.
+
+Live smoke command shape:
+
+```sh
+LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy \
+  --region us-east \
+  --execute \
+  --source-image linode/debian12 \
+  --type g6-nanode-1 \
+  --run-id "run-m4-smoke"
+```
 
 ## Cleanup
 
@@ -89,8 +121,9 @@ required tags are present:
 - `ttl=<timestamp>`
 
 Execute-mode cleanup is narrower than general cleanup. Capture only attempts to
-delete the current run's temporary capture-source Linode, and deploy only
-attempts to delete the current run's temporary deploy Linode. In both cases,
-cleanup proceeds only when the resource has all required tags matching the
-current run. If tags are missing or do not match, cleanup is skipped and the
-manifest reports the skip.
+delete the current run's temporary capture-source Linode, deploy only attempts
+to delete the current run's temporary deploy Linode, and capture-deploy only
+attempts to delete those two temporary Linodes for the current combined run. In
+all cases, cleanup proceeds only when the resource has all required tags
+matching the current run. If tags are missing or do not match, cleanup is
+skipped and the manifest reports the skip.

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,13 +9,14 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 - Create sanitized manifest previews for dry-run planning.
 - Define a stable tag contract for resource rediscovery.
 - Make cleanup selection testable without cloud access.
-- Allow single-region capture and deploy execution only after explicit opt-in.
+- Allow single-region capture, deploy, and capture-deploy execution only after
+  explicit opt-in.
 
 ## Non-Goals
 
 - No implicit Linode API mutations.
-- No capture-deploy execution, multi-region execution, GitHub Actions mutation,
-  or external scheduler integration.
+- No multi-region execution, GitHub Actions mutation, or external scheduler
+  integration.
 - CI exists to run `make check`.
 
 ## Components
@@ -23,6 +24,7 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 - `cli.py` owns command parsing and JSON output.
 - `capture.py` owns dry-run capture manifests and execute-mode orchestration.
 - `deploy.py` owns dry-run deploy manifests and execute-mode orchestration.
+- `capture_deploy.py` owns the combined capture-deploy execute orchestration.
 - `manifest.py` owns manifest creation, tag generation, and sanitized
   serialization.
 - `regions.py` owns one-or-many region parsing.
@@ -40,9 +42,11 @@ contract.
 M2 capture execution adds `execution_mode`, ordered `steps`, `resources`,
 `capture_source`, `custom_image`, and `cleanup` fields. M3 deploy execution adds
 `execution_mode`, ordered `steps`, `resources`, `deploy_source`,
-`deploy_instance`, `validation`, and `cleanup` fields. Internal manifests may
-carry provider resource identifiers required for cleanup and debugging. Normal
-stdout uses sanitized serialization, which redacts provider identifiers before
+`deploy_instance`, `validation`, and `cleanup` fields. M4 capture-deploy
+execution adds top-level `execution_mode`, `steps`, `resources`, `capture`,
+`deploy`, `validation`, and `cleanup` fields. Internal manifests may carry
+provider resource identifiers required for cleanup and debugging. Normal stdout
+uses sanitized serialization, which redacts provider identifiers before
 printing.
 
 ## Capture Execution Boundary
@@ -78,3 +82,23 @@ The execute flow is intentionally linear:
 
 M3 does not perform SSH, cloud-init, service, or application readiness
 validation.
+
+## Capture-Deploy Execution Boundary
+
+`capture-deploy` without `--execute` remains non-mutating and does not read
+`LINODE_TOKEN`. `capture-deploy --execute` requires exactly one region, a source
+image, a Linode type, and `LINODE_TOKEN`.
+
+The execute flow reuses the capture and deploy internals:
+
+1. run capture with `mode=capture-deploy` and `component=capture`,
+2. pass the internal custom image id to deploy without exposing it in stdout,
+3. run deploy with `mode=capture-deploy` and `component=deploy`,
+4. surface deploy's provider/API-level validation result,
+5. delete the temporary capture-source Linode when its current-run tags match,
+6. delete or preserve the temporary deploy Linode according to
+   `--preserve-instance`,
+7. preserve the custom image as the deliverable.
+
+Capture-deploy cleanup is tag-scoped. It only deletes resources carrying all
+required tags for the current run, including the matching component tag.

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,8 +7,8 @@ non-mutating; capture and deploy execution require explicit opt-in.
 
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
-- The CLI reads `LINODE_TOKEN` only for `capture --execute` and
-  `deploy --execute`.
+- The CLI reads `LINODE_TOKEN` only for `capture --execute`,
+  `deploy --execute`, or `capture-deploy --execute`.
 - Dry-run commands do not read token values.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
 - Normal stdout and stderr must not print tokens, authorization headers, root
@@ -16,8 +16,8 @@ non-mutating; capture and deploy execution require explicit opt-in.
 
 ## Execute Permissions
 
-`capture --execute` and `deploy --execute` need a personal access token or
-equivalent OAuth access that can:
+`capture --execute`, `deploy --execute`, and `capture-deploy --execute` need a
+personal access token or equivalent OAuth access that can:
 
 - read the current profile for preflight,
 - create, read, shut down, and delete temporary Linodes,
@@ -48,12 +48,16 @@ loss prevention system.
 
 ## Mutation Safety
 
-`plan` is dry-run only. `capture` and `deploy` are dry-run unless `--execute`
-is provided. `capture-deploy` returns an explicit placeholder response.
-`cleanup` currently selects candidates from provided data structures and does
-not call Linode.
+`plan` is dry-run only. `capture`, `deploy`, and `capture-deploy` are dry-run
+unless `--execute` is provided. `cleanup` currently selects candidates from
+provided data structures and does not call Linode.
 
-`capture --execute` and `deploy --execute` fail before mutation if required
-options or `LINODE_TOKEN` are missing. They perform non-mutating token preflight
-before creating resources. Partial-failure cleanup only targets resources whose
-required tags exactly match the current run.
+`capture --execute`, `deploy --execute`, and `capture-deploy --execute` fail
+before mutation if required options or `LINODE_TOKEN` are missing. They perform
+non-mutating token preflight before creating resources. Partial-failure cleanup
+only targets resources whose required tags exactly match the current run.
+
+`capture-deploy --execute` creates resources with `mode=capture-deploy` and a
+component-specific tag: capture resources use `component=capture`, and deploy
+resources use `component=deploy`. The custom image is preserved by default.
+Temporary Linodes are deleted only when all required tags match the current run.

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -29,6 +29,10 @@ class CaptureOptions:
     instance_type: str | None = None
     image_label: str | None = None
     preserve_source: bool = False
+    command: str = "capture"
+    mode: str = "capture"
+    component: str = "capture"
+    defer_cleanup: bool = False
 
 
 def capture_plan(
@@ -60,8 +64,9 @@ def capture_plan(
 
 def dry_run_manifest(options: CaptureOptions) -> dict[str, Any]:
     manifest = create_manifest(
-        command="capture",
-        mode="capture",
+        command=options.command,
+        mode=options.mode,
+        component=options.component,
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
@@ -80,8 +85,9 @@ def execute_capture(
 ) -> dict[str, Any]:
     validate_execute_options(options)
     manifest = create_manifest(
-        command="capture",
-        mode="capture",
+        command=options.command,
+        mode=options.mode,
+        component=options.component,
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
@@ -97,7 +103,7 @@ def execute_capture(
     for action in manifest["planned_actions"]:
         action["mutates"] = True
 
-    run_client = client or LinodeClient.from_env()
+    run_client = client or LinodeClient.from_env(command=options.command)
     capture_source: dict[str, Any] | None = None
     custom_image: dict[str, Any] | None = None
 
@@ -179,13 +185,16 @@ def execute_capture(
         manifest["resources"][1] = dict(custom_image)
         finish_step(manifest, "wait_custom_image_available")
 
-        cleanup_capture_source(
-            manifest,
-            run_client,
-            capture_source=capture_source,
-            preserve_source=options.preserve_source,
-            required_tags=tags,
-        )
+        if options.defer_cleanup:
+            manifest["cleanup"] = {"status": "deferred", "deleted": [], "preserved": []}
+        else:
+            cleanup_capture_source(
+                manifest,
+                run_client,
+                capture_source=capture_source,
+                preserve_source=options.preserve_source,
+                required_tags=tags,
+            )
         manifest["status"] = "succeeded"
         return manifest
     except Exception as exc:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -1,0 +1,402 @@
+"""Combined capture-deploy execution orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .capture import (
+    CaptureError,
+    CaptureOptions,
+    cleanup_capture_source,
+    execute_capture,
+)
+from .deploy import (
+    DeployError,
+    DeployOptions,
+    cleanup_deploy_instance,
+    execute_deploy,
+)
+from .linode_api import LinodeClient, LinodeClientProtocol
+from .manifest import create_manifest, generate_tags
+
+
+class CaptureDeployError(ValueError):
+    """Raised when capture-deploy cannot safely complete."""
+
+    def __init__(self, message: str, manifest: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.manifest = manifest
+
+
+@dataclass(frozen=True)
+class CaptureDeployOptions:
+    regions: list[str]
+    run_id: str | None = None
+    ttl: str | None = None
+    execute: bool = False
+    source_image: str | None = None
+    instance_type: str | None = None
+    preserve_instance: bool = False
+
+
+def capture_deploy_plan(
+    *,
+    regions: list[str],
+    run_id: str | None = None,
+    ttl: str | None = None,
+    execute: bool = False,
+    source_image: str | None = None,
+    instance_type: str | None = None,
+    preserve_instance: bool = False,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    options = CaptureDeployOptions(
+        regions=regions,
+        run_id=run_id,
+        ttl=ttl,
+        execute=execute,
+        source_image=source_image,
+        instance_type=instance_type,
+        preserve_instance=preserve_instance,
+    )
+    if not execute:
+        return dry_run_manifest(options)
+    return execute_capture_deploy(options, client=client)
+
+
+def dry_run_manifest(options: CaptureDeployOptions) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="capture-deploy",
+        mode="capture-deploy",
+        component="capture",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=True,
+        status="planned",
+    )
+    apply_capture_deploy_shape(manifest, mutates=False)
+    manifest["execution_mode"] = "dry-run"
+    manifest["message"] = "capture-deploy is non-mutating unless --execute is provided"
+    return manifest
+
+
+def execute_capture_deploy(
+    options: CaptureDeployOptions,
+    *,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    validate_execute_options(options)
+    manifest = create_manifest(
+        command="capture-deploy",
+        mode="capture-deploy",
+        component="capture",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=False,
+        status="running",
+    )
+    apply_capture_deploy_shape(manifest, mutates=True)
+    manifest["execution_mode"] = "execute"
+    manifest["steps"] = []
+    manifest["resources"] = []
+    manifest["capture"] = {}
+    manifest["deploy"] = {}
+    manifest["validation"] = {"status": "not_started", "checks": []}
+    manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+
+    run_client = client or LinodeClient.from_env(command="capture-deploy")
+    capture_manifest: dict[str, Any] | None = None
+    deploy_manifest: dict[str, Any] | None = None
+
+    try:
+        append_step(manifest, "capture", mutates=True, status="running")
+        capture_manifest = execute_capture(
+            CaptureOptions(
+                regions=options.regions,
+                run_id=manifest["run_id"],
+                ttl=manifest["ttl"],
+                execute=True,
+                source_image=required_text(options.source_image),
+                instance_type=required_text(options.instance_type),
+                preserve_source=False,
+                command="capture-deploy",
+                mode="capture-deploy",
+                component="capture",
+                defer_cleanup=True,
+            ),
+            client=run_client,
+        )
+        finish_step(manifest, "capture")
+        sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
+
+        image_id = required_text(capture_manifest.get("custom_image", {}).get("image_id"))
+
+        append_step(manifest, "deploy", mutates=True, status="running")
+        deploy_manifest = execute_deploy(
+            DeployOptions(
+                regions=options.regions,
+                run_id=manifest["run_id"],
+                ttl=manifest["ttl"],
+                execute=True,
+                image_id=image_id,
+                instance_type=required_text(options.instance_type),
+                preserve_instance=options.preserve_instance,
+                command="capture-deploy",
+                mode="capture-deploy",
+                component="deploy",
+                defer_cleanup=True,
+            ),
+            client=run_client,
+        )
+        finish_step(manifest, "deploy")
+        sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
+
+        append_step(manifest, "validation", mutates=False, status="running")
+        manifest["validation"] = dict(deploy_manifest.get("validation", {}))
+        finish_step(manifest, "validation")
+
+        append_step(manifest, "cleanup", mutates=True, status="running")
+        run_deferred_cleanup(
+            run_client,
+            capture_manifest=capture_manifest,
+            deploy_manifest=deploy_manifest,
+            preserve_instance=options.preserve_instance,
+        )
+        finish_step(manifest, "cleanup")
+
+        sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
+        manifest["status"] = "succeeded"
+        return manifest
+    except Exception as exc:
+        mark_running_step_failed(manifest)
+        if isinstance(exc, CaptureError) and exc.manifest is not None:
+            capture_manifest = exc.manifest
+        if isinstance(exc, DeployError) and exc.manifest is not None:
+            deploy_manifest = exc.manifest
+        try_cleanup_after_failure(
+            run_client,
+            capture_manifest=capture_manifest,
+            deploy_manifest=deploy_manifest,
+            preserve_instance=options.preserve_instance,
+        )
+        sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
+        manifest["status"] = "failed"
+        manifest["errors"] = [safe_error_message(exc)]
+        raise CaptureDeployError("capture-deploy --execute failed", manifest) from exc
+
+
+def validate_execute_options(options: CaptureDeployOptions) -> None:
+    if len(options.regions) != 1:
+        raise CaptureDeployError("capture-deploy --execute requires exactly one region")
+    if not options.source_image:
+        raise CaptureDeployError("capture-deploy --execute requires --source-image")
+    if not options.instance_type:
+        raise CaptureDeployError("capture-deploy --execute requires --type")
+
+
+def apply_capture_deploy_shape(manifest: dict[str, Any], *, mutates: bool) -> None:
+    capture_tags = generate_tags(
+        run_id=manifest["run_id"],
+        mode="capture-deploy",
+        component="capture",
+        ttl=manifest["ttl"],
+    )
+    deploy_tags = generate_tags(
+        run_id=manifest["run_id"],
+        mode="capture-deploy",
+        component="deploy",
+        ttl=manifest["ttl"],
+    )
+    manifest["component_tags"] = {
+        "capture": capture_tags,
+        "deploy": deploy_tags,
+    }
+    manifest["planned_actions"] = [
+        {
+            "action": action,
+            "region": region,
+            "component": component,
+            "mutates": mutates,
+            "tags": tags,
+        }
+        for region in manifest["regions"]
+        for action, component, tags in (
+            ("capture", "capture", capture_tags),
+            ("deploy", "deploy", deploy_tags),
+        )
+    ]
+
+
+def run_deferred_cleanup(
+    client: LinodeClientProtocol,
+    *,
+    capture_manifest: dict[str, Any],
+    deploy_manifest: dict[str, Any],
+    preserve_instance: bool,
+) -> None:
+    cleanup_capture_source(
+        capture_manifest,
+        client,
+        capture_source=capture_manifest["capture_source"],
+        preserve_source=False,
+        required_tags=list(capture_manifest["tags"]),
+    )
+    cleanup_deploy_instance(
+        deploy_manifest,
+        client,
+        deploy_instance=deploy_manifest["deploy_instance"],
+        preserve_instance=preserve_instance,
+        required_tags=list(deploy_manifest["tags"]),
+    )
+
+
+def try_cleanup_after_failure(
+    client: LinodeClientProtocol,
+    *,
+    capture_manifest: dict[str, Any] | None,
+    deploy_manifest: dict[str, Any] | None,
+    preserve_instance: bool,
+) -> None:
+    if capture_manifest is not None and cleanup_status(capture_manifest) == "deferred":
+        try:
+            cleanup_capture_source(
+                capture_manifest,
+                client,
+                capture_source=capture_manifest["capture_source"],
+                preserve_source=False,
+                required_tags=list(capture_manifest["tags"]),
+            )
+        except Exception:
+            capture_manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+
+    if deploy_manifest is not None and cleanup_status(deploy_manifest) == "deferred":
+        try:
+            cleanup_deploy_instance(
+                deploy_manifest,
+                client,
+                deploy_instance=deploy_manifest["deploy_instance"],
+                preserve_instance=preserve_instance,
+                required_tags=list(deploy_manifest["tags"]),
+            )
+        except Exception:
+            deploy_manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+
+
+def sync_manifest(
+    manifest: dict[str, Any],
+    *,
+    capture_manifest: dict[str, Any] | None,
+    deploy_manifest: dict[str, Any] | None,
+) -> None:
+    if capture_manifest is not None:
+        manifest["capture"] = {
+            "status": capture_manifest.get("status"),
+            "steps": capture_manifest.get("steps", []),
+            "resources": capture_manifest.get("resources", []),
+            "capture_source": capture_manifest.get("capture_source", {}),
+            "custom_image": capture_manifest.get("custom_image", {}),
+            "cleanup": capture_manifest.get("cleanup", {}),
+        }
+    if deploy_manifest is not None:
+        manifest["deploy"] = {
+            "status": deploy_manifest.get("status"),
+            "steps": deploy_manifest.get("steps", []),
+            "resources": deploy_manifest.get("resources", []),
+            "deploy_source": deploy_manifest.get("deploy_source", {}),
+            "deploy_instance": deploy_manifest.get("deploy_instance", {}),
+            "validation": deploy_manifest.get("validation", {}),
+            "cleanup": deploy_manifest.get("cleanup", {}),
+        }
+        manifest["validation"] = dict(deploy_manifest.get("validation", manifest["validation"]))
+
+    resources: list[dict[str, Any]] = []
+    if capture_manifest is not None:
+        resources.extend(capture_manifest.get("resources", []))
+    if deploy_manifest is not None:
+        resources.extend(deploy_manifest.get("resources", []))
+    manifest["resources"] = resources
+    manifest["cleanup"] = combined_cleanup(
+        capture_manifest=capture_manifest,
+        deploy_manifest=deploy_manifest,
+    )
+
+
+def combined_cleanup(
+    *,
+    capture_manifest: dict[str, Any] | None,
+    deploy_manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    deleted: list[dict[str, Any]] = []
+    preserved: list[dict[str, Any]] = []
+    capture_cleanup = cleanup_block(capture_manifest)
+    deploy_cleanup = cleanup_block(deploy_manifest)
+    deleted.extend(capture_cleanup.get("deleted", []))
+    deleted.extend(deploy_cleanup.get("deleted", []))
+    preserved.extend(capture_cleanup.get("preserved", []))
+    preserved.extend(deploy_cleanup.get("preserved", []))
+
+    if capture_manifest is not None and capture_manifest.get("custom_image"):
+        custom_image = dict(capture_manifest["custom_image"])
+        custom_image["reason"] = "deliverable"
+        preserved.append(custom_image)
+
+    statuses = [status for status in (capture_cleanup.get("status"), deploy_cleanup.get("status")) if status]
+    if any(status == "failed" for status in statuses):
+        status = "failed"
+    elif any(status == "deferred" for status in statuses):
+        status = "deferred"
+    elif statuses:
+        status = "completed"
+    else:
+        status = "not_started"
+
+    return {
+        "status": status,
+        "deleted": deleted,
+        "preserved": preserved,
+        "capture": capture_cleanup,
+        "deploy": deploy_cleanup,
+    }
+
+
+def cleanup_block(manifest: dict[str, Any] | None) -> dict[str, Any]:
+    if manifest is None:
+        return {"status": "not_started", "deleted": [], "preserved": []}
+    return dict(manifest.get("cleanup", {"status": "not_started", "deleted": [], "preserved": []}))
+
+
+def cleanup_status(manifest: dict[str, Any]) -> str:
+    return str(manifest.get("cleanup", {}).get("status", "not_started"))
+
+
+def append_step(manifest: dict[str, Any], name: str, *, mutates: bool, status: str) -> None:
+    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+
+
+def finish_step(manifest: dict[str, Any], name: str) -> None:
+    for step in reversed(manifest["steps"]):
+        if step["name"] == name:
+            step["status"] = "succeeded"
+            return
+
+
+def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+    for step in reversed(manifest.get("steps", [])):
+        if step.get("status") == "running":
+            step["status"] = "failed"
+            return
+
+
+def required_text(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CaptureDeployError("required capture-deploy value is missing")
+    return value
+
+
+def safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, (CaptureDeployError, CaptureError, DeployError)):
+        return str(exc)
+    return exc.__class__.__name__

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .cleanup import select_cleanup_candidates
 from .capture import CaptureError, capture_plan
+from .capture_deploy import CaptureDeployError, capture_deploy_plan
 from .deploy import DeployError, deploy_plan
 from .manifest import create_manifest, serialize_manifest
 from .regions import parse_regions
@@ -60,8 +61,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep the temporary deploy Linode after execution.",
     )
 
-    capture_deploy = subparsers.add_parser("capture-deploy", help="Placeholder combined command.")
+    capture_deploy = subparsers.add_parser("capture-deploy", help="Plan or execute capture plus deploy validation.")
     add_region_args(capture_deploy, required=True)
+    capture_deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    capture_deploy.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
+    capture_deploy.add_argument(
+        "--type",
+        dest="instance_type",
+        help="Linode type for the temporary capture and deploy Linodes.",
+    )
+    capture_deploy.add_argument(
+        "--preserve-instance",
+        action="store_true",
+        help="Keep the temporary deploy validation Linode after execution.",
+    )
 
     cleanup = subparsers.add_parser("cleanup", help="Placeholder cleanup command.")
     cleanup.add_argument("--run-id", help="Optional run id to include in the cleanup preview.")
@@ -106,17 +119,15 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     if args.command == "capture-deploy":
-        manifest = create_manifest(
-            command="capture-deploy",
-            mode="capture-deploy",
+        return capture_deploy_plan(
             regions=parse_regions(args.region),
             run_id=args.run_id,
             ttl=args.ttl,
-            dry_run=True,
-            status="placeholder",
+            execute=args.execute,
+            source_image=args.source_image,
+            instance_type=args.instance_type,
+            preserve_instance=args.preserve_instance,
         )
-        manifest["message"] = "capture-deploy is a non-mutating placeholder"
-        return manifest
 
     if args.command == "cleanup":
         manifest = create_manifest(
@@ -150,6 +161,12 @@ def main(argv: list[str] | None = None) -> int:
         if exc.manifest is not None:
             sys.stdout.write(serialize_manifest(exc.manifest))
             sys.stderr.write("deploy --execute failed\n")
+            return 1
+        parser.error(str(exc))
+    except CaptureDeployError as exc:
+        if exc.manifest is not None:
+            sys.stdout.write(serialize_manifest(exc.manifest))
+            sys.stderr.write("capture-deploy --execute failed\n")
             return 1
         parser.error(str(exc))
     except ValueError as exc:

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -28,6 +28,10 @@ class DeployOptions:
     image_id: str | None = None
     instance_type: str | None = None
     preserve_instance: bool = False
+    command: str = "deploy"
+    mode: str = "deploy"
+    component: str = "deploy"
+    defer_cleanup: bool = False
 
 
 def deploy_plan(
@@ -57,8 +61,9 @@ def deploy_plan(
 
 def dry_run_manifest(options: DeployOptions) -> dict[str, Any]:
     manifest = create_manifest(
-        command="deploy",
-        mode="deploy",
+        command=options.command,
+        mode=options.mode,
+        component=options.component,
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
@@ -77,8 +82,9 @@ def execute_deploy(
 ) -> dict[str, Any]:
     validate_execute_options(options)
     manifest = create_manifest(
-        command="deploy",
-        mode="deploy",
+        command=options.command,
+        mode=options.mode,
+        component=options.component,
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
@@ -95,7 +101,7 @@ def execute_deploy(
     for action in manifest["planned_actions"]:
         action["mutates"] = True
 
-    run_client = client or LinodeClient.from_env(command="deploy")
+    run_client = client or LinodeClient.from_env(command=options.command)
     deploy_instance: dict[str, Any] | None = None
 
     try:
@@ -142,13 +148,16 @@ def execute_deploy(
         }
         finish_step(manifest, "validate_deploy_instance")
 
-        cleanup_deploy_instance(
-            manifest,
-            run_client,
-            deploy_instance=deploy_instance,
-            preserve_instance=options.preserve_instance,
-            required_tags=tags,
-        )
+        if options.defer_cleanup:
+            manifest["cleanup"] = {"status": "deferred", "deleted": [], "preserved": []}
+        else:
+            cleanup_deploy_instance(
+                manifest,
+                run_client,
+                deploy_instance=deploy_instance,
+                preserve_instance=options.preserve_instance,
+                required_tags=tags,
+            )
         manifest["status"] = "succeeded"
         return manifest
     except Exception as exc:

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -78,6 +78,7 @@ def create_manifest(
     command: str,
     mode: str,
     regions: list[str],
+    component: str | None = None,
     run_id: str | None = None,
     ttl: str | None = None,
     dry_run: bool = True,
@@ -91,11 +92,12 @@ def create_manifest(
     created_at = format_timestamp(utc_now())
     manifest_run_id = run_id or f"run-{uuid4().hex[:12]}"
     manifest_ttl = ttl or default_ttl()
-    component = component_for_mode(mode)
+    manifest_component = component or component_for_mode(mode)
+    validate_component(manifest_component)
     tags = generate_tags(
         run_id=manifest_run_id,
         mode=mode,
-        component=component,
+        component=manifest_component,
         ttl=manifest_ttl,
     )
 
@@ -115,7 +117,7 @@ def create_manifest(
             {
                 "action": command,
                 "region": region,
-                "component": component,
+                "component": manifest_component,
                 "mutates": False,
                 "tags": tags,
             }

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from linode_image_lab.capture_deploy import CaptureDeployError, capture_deploy_plan
+from linode_image_lab.manifest import serialize_manifest
+
+
+class FakeLinodeClient:
+    def __init__(self, *, missing_deploy_tags: bool = False) -> None:
+        self.calls: list[str] = []
+        self.capture_tags: list[str] = []
+        self.deploy_tags: list[str] = []
+        self.image_tags: list[str] = []
+        self.deleted: list[int] = []
+        self.missing_deploy_tags = missing_deploy_tags
+
+    def preflight(self) -> None:
+        self.calls.append("preflight")
+
+    def create_instance(
+        self,
+        *,
+        region: str,
+        source_image: str,
+        instance_type: str,
+        label: str,
+        tags: list[str],
+        root_password: str,
+    ) -> dict[str, object]:
+        if source_image == "private/789":
+            self.calls.append("create_deploy_instance")
+            self.deploy_tags = tags
+            return {
+                "linode_id": 321,
+                "label": label,
+                "region": region,
+                "status": "provisioning",
+                "tags": [] if self.missing_deploy_tags else tags,
+            }
+
+        self.calls.append("create_capture_source")
+        self.capture_tags = tags
+        return {
+            "linode_id": 123,
+            "label": label,
+            "region": region,
+            "status": "provisioning",
+            "tags": tags,
+        }
+
+    def wait_instance_ready(self, linode_id: int) -> dict[str, object]:
+        if linode_id == 321:
+            self.calls.append("wait_deploy_instance_ready")
+            return {
+                "linode_id": linode_id,
+                "region": "us-east",
+                "status": "running",
+                "tags": [] if self.missing_deploy_tags else self.deploy_tags,
+            }
+
+        self.calls.append("wait_capture_source_ready")
+        return {
+            "linode_id": linode_id,
+            "region": "us-east",
+            "status": "running",
+            "tags": self.capture_tags,
+        }
+
+    def list_disks(self, linode_id: int) -> list[dict[str, object]]:
+        self.calls.append("list_disks")
+        return [{"disk_id": 456}]
+
+    def shutdown_instance(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("shutdown_capture_source")
+        return {"linode_id": linode_id}
+
+    def wait_instance_offline(self, linode_id: int) -> dict[str, object]:
+        self.calls.append("wait_capture_source_offline")
+        return {
+            "linode_id": linode_id,
+            "region": "us-east",
+            "status": "offline",
+            "tags": self.capture_tags,
+        }
+
+    def capture_image(
+        self,
+        *,
+        disk_id: int,
+        label: str,
+        tags: list[str],
+        description: str,
+        cloud_init: bool,
+    ) -> dict[str, object]:
+        self.calls.append("capture_image")
+        self.image_tags = tags
+        return {
+            "image_id": "private/789",
+            "label": label,
+            "status": "creating",
+            "tags": tags,
+        }
+
+    def wait_image_available(self, image_id: str) -> dict[str, object]:
+        self.calls.append("wait_image_available")
+        return {
+            "image_id": image_id,
+            "status": "available",
+            "tags": self.image_tags,
+        }
+
+    def delete_instance(self, linode_id: int) -> dict[str, object]:
+        if linode_id == 123:
+            self.calls.append("delete_capture_source")
+        else:
+            self.calls.append("delete_deploy_instance")
+        self.deleted.append(linode_id)
+        return {"linode_id": linode_id, "deleted": True}
+
+
+class ExplodingClient:
+    def preflight(self) -> None:
+        raise AssertionError("dry-run must not call the client")
+
+
+class CaptureDeployExecutionTests(unittest.TestCase):
+    def test_dry_run_does_not_read_token_or_call_execution(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("linode_image_lab.capture_deploy.execute_capture") as capture,
+            patch("linode_image_lab.capture_deploy.execute_deploy") as deploy,
+        ):
+            manifest = capture_deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                client=ExplodingClient(),
+            )
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "dry-run")
+        capture.assert_not_called()
+        deploy.assert_not_called()
+
+    def test_execute_requires_token_without_client(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "LINODE_TOKEN"):
+                capture_deploy_plan(
+                    regions=["us-east"],
+                    run_id="run-test",
+                    ttl="2030-01-01T00:00:00Z",
+                    execute=True,
+                    source_image="linode/debian12",
+                    instance_type="g6-nanode-1",
+                )
+
+    def test_execute_requires_inputs_before_token(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(CaptureDeployError, "--source-image"):
+                capture_deploy_plan(
+                    regions=["us-east"],
+                    run_id="run-test",
+                    ttl="2030-01-01T00:00:00Z",
+                    execute=True,
+                    instance_type="g6-nanode-1",
+                )
+
+    def test_execute_requires_single_region(self) -> None:
+        with self.assertRaisesRegex(CaptureDeployError, "exactly one region"):
+            capture_deploy_plan(
+                regions=["us-east", "us-west"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=FakeLinodeClient(),
+            )
+
+    def test_execute_with_fake_client_records_capture_deploy_cleanup_order(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertEqual(
+            client.calls,
+            [
+                "preflight",
+                "create_capture_source",
+                "wait_capture_source_ready",
+                "list_disks",
+                "shutdown_capture_source",
+                "wait_capture_source_offline",
+                "capture_image",
+                "wait_image_available",
+                "preflight",
+                "create_deploy_instance",
+                "wait_deploy_instance_ready",
+                "delete_capture_source",
+                "delete_deploy_instance",
+            ],
+        )
+        self.assertEqual(manifest["status"], "succeeded")
+        self.assertEqual(manifest["capture"]["custom_image"]["image_id"], "private/789")
+        self.assertEqual(manifest["deploy"]["deploy_source"]["image_id"], "private/789")
+        self.assertEqual(manifest["validation"]["status"], "succeeded")
+        self.assertEqual(manifest["cleanup"]["status"], "completed")
+        self.assertEqual(client.deleted, [123, 321])
+
+    def test_execute_applies_component_tags_to_created_resources(self) -> None:
+        client = FakeLinodeClient()
+
+        capture_deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertIn("mode=capture-deploy", client.capture_tags)
+        self.assertIn("component=capture", client.capture_tags)
+        self.assertIn("mode=capture-deploy", client.deploy_tags)
+        self.assertIn("component=deploy", client.deploy_tags)
+
+    def test_preserve_instance_keeps_deploy_instance_only(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            preserve_instance=True,
+            client=client,
+        )
+
+        self.assertEqual(client.deleted, [123])
+        self.assertEqual(manifest["deploy"]["cleanup"]["status"], "preserved")
+
+    def test_cleanup_skips_deploy_resource_missing_current_run_tags(self) -> None:
+        client = FakeLinodeClient(missing_deploy_tags=True)
+
+        with self.assertRaises(CaptureDeployError) as raised:
+            capture_deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(client.deleted, [123])
+        self.assertIsNotNone(raised.exception.manifest)
+        self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["status"], "skipped_tag_mismatch")
+
+    def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
+        manifest = capture_deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=FakeLinodeClient(),
+        )
+
+        exported = json.loads(serialize_manifest(manifest))
+
+        self.assertEqual(exported["capture"]["capture_source"]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["capture"]["custom_image"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy"]["deploy_source"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy"]["deploy_instance"]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["cleanup"]["preserved"][0]["image_id"], "[REDACTED]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -80,6 +80,14 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--type", error.getvalue())
 
+    def test_capture_deploy_execute_requires_options_before_mutation(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["capture-deploy", "--region", "us-east", "--execute", "--source-image", "linode/debian12"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--type", error.getvalue())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `capture-deploy --execute` orchestration that reuses capture and deploy internals with `mode=capture-deploy` component-specific tags.
- Preserve dry-run behavior and token boundaries; execute mode validates single-region inputs, `--source-image`, `--type`, and `LINODE_TOKEN` before mutation.
- Add combined manifest sections for steps, resources, capture, deploy, validation, and cleanup, with provider identifiers redacted in serialized output.
- Add focused unit coverage and update README, workflow, security, and design docs.

## Scope Confirmation
- In scope: single-region capture-deploy execution, CLI flags, manifest structure, tag-scoped cleanup, tests, and docs.
- Out of scope: multi-region execution, scheduler or CI changes, SSH/app-level validation, live API tests, performance tuning, and retry behavior beyond current patterns.

## Validation
- `make check` passed.
- `make security-check` passed.
- Tests use fake clients only; no live Linode API calls are performed.

## Residual Risks
- CI status must be confirmed after GitHub finishes running the PR checks.
- Validation remains provider/API-level only; SSH, cloud-init, service, and application readiness checks remain out of scope.