### PR TITLE
[codex] Polish manifest consistency and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ PYTHONPATH=src python3 -m linode_image_lab.cli cleanup
 
 `capture --execute` requires exactly one region, `--source-image`, `--type`, and
 `LINODE_TOKEN`. It creates a temporary capture-source Linode, waits for it to be
-ready, powers it off, captures a custom image from its disk, waits for the image,
-then deletes the temporary source unless `--preserve-source` is provided.
+ready, checks provider/API-level region, tags, and disk presence, powers it off,
+creates a custom image, waits for image availability, then deletes the temporary
+source unless `--preserve-source` is provided.
 
 `deploy --execute` requires exactly one region, `--image-id`, `--type`, and
 `LINODE_TOKEN`. `--image-id` is the existing custom image to boot from. The
@@ -74,6 +75,20 @@ validation Linode from that image, validates provider/API-level running status,
 requested region, and required tags, then deletes the temporary capture-source
 and deploy validation Linodes. The custom image is preserved by default as the
 deliverable. `--preserve-instance` keeps only the deploy validation Linode.
+
+## Manifest Shape
+
+Execute manifests use consistent top-level `status`, `steps`, `resources`,
+`validation`, and `cleanup` fields. For `capture-deploy`, top-level
+`resources` is the combined resource list, while `capture.resources` and
+`deploy.resources` show phase-specific resource views. Top-level `cleanup`
+summarizes combined cleanup; nested cleanup blocks show capture and deploy
+results separately.
+
+Cleanup status values are literal: `deleted` means a temporary Linode was
+deleted, `preserved` means a resource was kept or skipped for safety,
+`completed` means combined cleanup finished, and `failed` means cleanup did not
+complete.
 
 Normal stdout is a redacted, export-safe manifest view. Local in-memory
 manifests may retain provider identifiers needed for cleanup and debugging, but

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -23,13 +23,15 @@ Execution steps:
 1. preflight token access without mutating resources,
 2. create a temporary capture-source Linode from the source image,
 3. wait until the source is ready,
-4. validate requested region, required tags, and disk presence,
+4. validate provider/API-level region, required tags, and disk presence,
 5. power off the source,
 6. create a custom image from the selected disk,
-7. wait until the image is available,
+7. wait until the provider reports the image is available,
 8. delete the temporary source unless `--preserve-source` is set.
 
 The custom image is preserved by default because it is the capture deliverable.
+Capture validation stops at provider/API data; it does not perform SSH,
+cloud-init, service, or application readiness checks.
 
 ## Deploy
 
@@ -56,7 +58,7 @@ Execution steps:
 The deploy instance is deleted by default because deploy execution is a quick
 validation path, not a long-lived server creation flow.
 
-M3 deploy validation stops at provider/API-level instance creation. It does not
+Deploy validation stops at provider/API-level instance creation. It does not
 perform SSH, cloud-init, service, or application readiness checks.
 
 Live smoke command shape:
@@ -97,6 +99,10 @@ The internal image id is passed directly from capture to deploy. Normal stdout
 redacts provider identifiers, so the image id is not exposed in serialized
 manifests.
 
+Capture-deploy intentionally runs the non-mutating API preflight inside both
+the capture and deploy phases. This keeps each phase independently safe and
+reusable, so combined manifests may show two `preflight_api_access` steps.
+
 Live smoke command shape:
 
 ```sh
@@ -125,5 +131,25 @@ delete the current run's temporary capture-source Linode, deploy only attempts
 to delete the current run's temporary deploy Linode, and capture-deploy only
 attempts to delete those two temporary Linodes for the current combined run. In
 all cases, cleanup proceeds only when the resource has all required tags
-matching the current run. If tags are missing or do not match, cleanup is
-skipped and the manifest reports the skip.
+matching the current run. If tags are missing or do not match, cleanup preserves
+the resource and records `reason=tag_mismatch`.
+
+Cleanup manifests use the same fields across commands: `status`, `deleted`,
+and `preserved`. `deleted` lists temporary Linodes removed after required tags
+matched. `preserved` lists resources kept by request or kept because required
+tags did not match, with a `reason` such as `requested`, `tag_mismatch`, or
+`deliverable`. In capture-deploy, top-level cleanup is the combined summary;
+`capture.cleanup` and `deploy.cleanup` are the phase-specific results.
+
+## Manifest Structure
+
+Single-command execute manifests expose top-level `status`, `steps`,
+`resources`, `validation`, and `cleanup`. Capture-deploy keeps the same
+top-level fields and also nests `capture` and `deploy` sections. Top-level
+`resources` is the combined list for the whole run. Nested `capture.resources`
+and `deploy.resources` are phase-specific slices of that same lifecycle.
+
+`validation` means provider/API-level checks only: resource state, requested
+region, required tags, disk presence for capture, and image availability for
+capture. It does not include SSH, app health, service readiness, or cloud-init
+completion checks.

--- a/docs/design.md
+++ b/docs/design.md
@@ -36,17 +36,20 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 
 Manifests are plain JSON-compatible dictionaries. They include schema version,
 project, command, mode, regions, timestamps, dry-run status, tags, and planned
-actions. Future milestones can add fields while preserving the required tag
-contract.
+actions. Serialized manifests use stable JSON formatting and redacted provider
+identifiers.
 
 M2 capture execution adds `execution_mode`, ordered `steps`, `resources`,
-`capture_source`, `custom_image`, and `cleanup` fields. M3 deploy execution adds
-`execution_mode`, ordered `steps`, `resources`, `deploy_source`,
+`capture_source`, `custom_image`, `validation`, and `cleanup` fields. M3 deploy
+execution adds `execution_mode`, ordered `steps`, `resources`, `deploy_source`,
 `deploy_instance`, `validation`, and `cleanup` fields. M4 capture-deploy
 execution adds top-level `execution_mode`, `steps`, `resources`, `capture`,
-`deploy`, `validation`, and `cleanup` fields. Internal manifests may carry
-provider resource identifiers required for cleanup and debugging. Normal stdout
-uses sanitized serialization, which redacts provider identifiers before
+`deploy`, `validation`, and `cleanup` fields. Top-level `resources` is the
+combined resource list; nested `capture.resources` and `deploy.resources` are
+phase-specific views. Top-level `cleanup` is the combined cleanup summary;
+nested cleanup blocks preserve phase-specific status. Internal manifests may
+carry provider resource identifiers required for cleanup and debugging. Normal
+stdout uses sanitized serialization, which redacts provider identifiers before
 printing.
 
 ## Capture Execution Boundary
@@ -65,6 +68,9 @@ The execute flow is intentionally linear:
 6. capture a custom image from the selected disk,
 7. wait for image availability,
 8. delete or preserve the source according to explicit flags.
+
+Capture validation is provider/API-level only. It verifies region, required
+tags, disk presence, image availability, and image tags from API responses.
 
 ## Deploy Execution Boundary
 
@@ -102,3 +108,15 @@ The execute flow reuses the capture and deploy internals:
 
 Capture-deploy cleanup is tag-scoped. It only deletes resources carrying all
 required tags for the current run, including the matching component tag.
+Because capture and deploy remain independently reusable, capture-deploy runs
+each phase's non-mutating API preflight. Seeing two `preflight_api_access`
+steps in a combined manifest is expected.
+
+## Cleanup Semantics
+
+Cleanup status is narrow and literal. `deleted` means a temporary Linode was
+deleted after matching current-run tags. `preserved` means no deletion occurred
+for that resource because preservation was requested or tags did not match.
+`completed` is reserved for combined cleanup after the phase cleanup blocks
+finish. `failed` means cleanup did not complete. Preserved entries include a
+`reason`; the custom image uses `deliverable`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -56,8 +56,15 @@ provided data structures and does not call Linode.
 before mutation if required options or `LINODE_TOKEN` are missing. They perform
 non-mutating token preflight before creating resources. Partial-failure cleanup
 only targets resources whose required tags exactly match the current run.
+Tag mismatches are represented as preserved resources in manifests, not as
+deletion attempts.
 
 `capture-deploy --execute` creates resources with `mode=capture-deploy` and a
 component-specific tag: capture resources use `component=capture`, and deploy
 resources use `component=deploy`. The custom image is preserved by default.
 Temporary Linodes are deleted only when all required tags match the current run.
+
+Validation is limited to provider/API responses: resource state, requested
+region, required tags, disk presence for capture, and image availability for
+capture. It does not perform SSH, cloud-init, service, or application readiness
+checks.

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -99,6 +99,7 @@ def execute_capture(
     manifest["resources"] = []
     manifest["capture_source"] = {}
     manifest["custom_image"] = {}
+    manifest["validation"] = {"status": "not_started", "checks": []}
     manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
     for action in manifest["planned_actions"]:
         action["mutates"] = True
@@ -108,9 +109,9 @@ def execute_capture(
     custom_image: dict[str, Any] | None = None
 
     try:
-        append_step(manifest, "preflight", mutates=False, status="running")
+        append_step(manifest, "preflight_api_access", mutates=False, status="running")
         run_client.preflight()
-        finish_step(manifest, "preflight")
+        finish_step(manifest, "preflight_api_access")
 
         tags = list(manifest["tags"])
         region = options.regions[0]
@@ -140,14 +141,24 @@ def execute_capture(
         manifest["resources"][0] = dict(capture_source)
         finish_step(manifest, "wait_capture_source_ready")
 
-        append_step(manifest, "validate_capture_source", mutates=False, status="running")
+        append_step(manifest, "validate_capture_source_api", mutates=False, status="running")
+        manifest["validation"] = {
+            "status": "running",
+            "checks": [
+                "source_region_matches",
+                "source_required_tags_match",
+                "source_disk_found",
+                "custom_image_available",
+                "custom_image_required_tags_match",
+            ],
+        }
         validate_created_resource(capture_source, required_tags=tags, region=region)
         disks = run_client.list_disks(required_int(capture_source.get("linode_id")))
         disk = first_disk(disks)
         capture_source["disk_id"] = disk["disk_id"]
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"][0] = dict(capture_source)
-        finish_step(manifest, "validate_capture_source")
+        finish_step(manifest, "validate_capture_source_api")
 
         append_step(manifest, "shutdown_capture_source", mutates=True, status="running")
         run_client.shutdown_instance(required_int(capture_source.get("linode_id")))
@@ -162,7 +173,7 @@ def execute_capture(
         manifest["resources"][0] = dict(capture_source)
         finish_step(manifest, "wait_capture_source_offline")
 
-        append_step(manifest, "capture_custom_image", mutates=True, status="running")
+        append_step(manifest, "create_custom_image", mutates=True, status="running")
         custom_image = run_client.capture_image(
             disk_id=required_int(capture_source.get("disk_id")),
             label=image_label,
@@ -173,7 +184,7 @@ def execute_capture(
         custom_image["resource_type"] = "image"
         manifest["custom_image"] = dict(custom_image)
         manifest["resources"].append(dict(custom_image))
-        finish_step(manifest, "capture_custom_image")
+        finish_step(manifest, "create_custom_image")
 
         append_step(manifest, "wait_custom_image_available", mutates=False, status="running")
         custom_image = merge_resource(
@@ -183,6 +194,16 @@ def execute_capture(
         validate_created_resource(custom_image, required_tags=tags)
         manifest["custom_image"] = dict(custom_image)
         manifest["resources"][1] = dict(custom_image)
+        manifest["validation"] = {
+            "status": "succeeded",
+            "checks": [
+                "source_region_matches",
+                "source_required_tags_match",
+                "source_disk_found",
+                "custom_image_available",
+                "custom_image_required_tags_match",
+            ],
+        }
         finish_step(manifest, "wait_custom_image_available")
 
         if options.defer_cleanup:
@@ -213,16 +234,18 @@ def execute_capture(
             except Exception:
                 mark_running_step_failed(manifest)
                 manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+        if manifest.get("validation", {}).get("status") == "running":
+            manifest["validation"]["status"] = "failed"
         raise CaptureError("capture --execute failed", manifest) from exc
 
 
 def validate_execute_options(options: CaptureOptions) -> None:
     if len(options.regions) != 1:
-        raise CaptureError("capture --execute requires exactly one region")
+        raise CaptureError("capture --execute requires exactly one non-empty --region")
     if not options.source_image:
-        raise CaptureError("capture --execute requires --source-image")
+        raise CaptureError("capture --execute requires --source-image for the temporary capture Linode")
     if not options.instance_type:
-        raise CaptureError("capture --execute requires --type")
+        raise CaptureError("capture --execute requires --type for the temporary capture Linode")
 
 
 def cleanup_capture_source(
@@ -233,24 +256,48 @@ def cleanup_capture_source(
     preserve_source: bool,
     required_tags: list[str],
 ) -> None:
-    append_step(manifest, "cleanup_capture_source", mutates=not preserve_source, status="running")
+    can_delete = has_required_tags(capture_source, required_tags)
+    cleanup_action = "delete" if not preserve_source and can_delete else "preserve"
+    append_step(
+        manifest,
+        "cleanup_capture_source",
+        mutates=cleanup_action == "delete",
+        status="running",
+        action=cleanup_action,
+    )
     cleanup = {"status": "not_started", "deleted": [], "preserved": []}
     if preserve_source:
         cleanup["status"] = "preserved"
-        cleanup["preserved"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
-    elif has_required_tags(capture_source, required_tags):
+        cleanup["preserved"].append(
+            {"resource_type": "linode", "linode_id": capture_source.get("linode_id"), "reason": "requested"}
+        )
+    elif can_delete:
         client.delete_instance(required_int(capture_source.get("linode_id")))
         cleanup["status"] = "deleted"
-        cleanup["deleted"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
+        cleanup["deleted"].append(
+            {"resource_type": "linode", "linode_id": capture_source.get("linode_id"), "reason": "tag_match"}
+        )
     else:
-        cleanup["status"] = "skipped_tag_mismatch"
-        cleanup["preserved"].append({"resource_type": "linode", "linode_id": capture_source.get("linode_id")})
+        cleanup["status"] = "preserved"
+        cleanup["preserved"].append(
+            {"resource_type": "linode", "linode_id": capture_source.get("linode_id"), "reason": "tag_mismatch"}
+        )
     manifest["cleanup"] = cleanup
     finish_step(manifest, "cleanup_capture_source")
 
 
-def append_step(manifest: dict[str, Any], name: str, *, mutates: bool, status: str) -> None:
-    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+def append_step(
+    manifest: dict[str, Any],
+    name: str,
+    *,
+    mutates: bool,
+    status: str,
+    action: str | None = None,
+) -> None:
+    step = {"name": name, "mutates": mutates, "status": status}
+    if action is not None:
+        step["action"] = action
+    manifest["steps"].append(step)
 
 
 def finish_step(manifest: dict[str, Any], name: str) -> None:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -112,7 +112,7 @@ def execute_capture_deploy(
     deploy_manifest: dict[str, Any] | None = None
 
     try:
-        append_step(manifest, "capture", mutates=True, status="running")
+        append_step(manifest, "run_capture_phase", mutates=True, status="running")
         capture_manifest = execute_capture(
             CaptureOptions(
                 regions=options.regions,
@@ -129,12 +129,12 @@ def execute_capture_deploy(
             ),
             client=run_client,
         )
-        finish_step(manifest, "capture")
+        finish_step(manifest, "run_capture_phase")
         sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
 
         image_id = required_text(capture_manifest.get("custom_image", {}).get("image_id"))
 
-        append_step(manifest, "deploy", mutates=True, status="running")
+        append_step(manifest, "run_deploy_phase", mutates=True, status="running")
         deploy_manifest = execute_deploy(
             DeployOptions(
                 regions=options.regions,
@@ -151,21 +151,21 @@ def execute_capture_deploy(
             ),
             client=run_client,
         )
-        finish_step(manifest, "deploy")
+        finish_step(manifest, "run_deploy_phase")
         sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
 
-        append_step(manifest, "validation", mutates=False, status="running")
+        append_step(manifest, "record_deploy_validation", mutates=False, status="running")
         manifest["validation"] = dict(deploy_manifest.get("validation", {}))
-        finish_step(manifest, "validation")
+        finish_step(manifest, "record_deploy_validation")
 
-        append_step(manifest, "cleanup", mutates=True, status="running")
+        append_step(manifest, "cleanup_temporary_resources", mutates=True, status="running")
         run_deferred_cleanup(
             run_client,
             capture_manifest=capture_manifest,
             deploy_manifest=deploy_manifest,
             preserve_instance=options.preserve_instance,
         )
-        finish_step(manifest, "cleanup")
+        finish_step(manifest, "cleanup_temporary_resources")
 
         sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
         manifest["status"] = "succeeded"
@@ -190,11 +190,11 @@ def execute_capture_deploy(
 
 def validate_execute_options(options: CaptureDeployOptions) -> None:
     if len(options.regions) != 1:
-        raise CaptureDeployError("capture-deploy --execute requires exactly one region")
+        raise CaptureDeployError("capture-deploy --execute requires exactly one non-empty --region")
     if not options.source_image:
-        raise CaptureDeployError("capture-deploy --execute requires --source-image")
+        raise CaptureDeployError("capture-deploy --execute requires --source-image for the temporary capture Linode")
     if not options.instance_type:
-        raise CaptureDeployError("capture-deploy --execute requires --type")
+        raise CaptureDeployError("capture-deploy --execute requires --type for temporary capture and deploy Linodes")
 
 
 def apply_capture_deploy_shape(manifest: dict[str, Any], *, mutates: bool) -> None:
@@ -298,6 +298,7 @@ def sync_manifest(
             "resources": capture_manifest.get("resources", []),
             "capture_source": capture_manifest.get("capture_source", {}),
             "custom_image": capture_manifest.get("custom_image", {}),
+            "validation": capture_manifest.get("validation", {}),
             "cleanup": capture_manifest.get("cleanup", {}),
         }
     if deploy_manifest is not None:

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -105,9 +105,9 @@ def execute_deploy(
     deploy_instance: dict[str, Any] | None = None
 
     try:
-        append_step(manifest, "preflight", mutates=False, status="running")
+        append_step(manifest, "preflight_api_access", mutates=False, status="running")
         run_client.preflight()
-        finish_step(manifest, "preflight")
+        finish_step(manifest, "preflight_api_access")
 
         tags = list(manifest["tags"])
         region = options.regions[0]
@@ -136,7 +136,15 @@ def execute_deploy(
         manifest["resources"][0] = dict(deploy_instance)
         finish_step(manifest, "wait_deploy_instance_ready")
 
-        append_step(manifest, "validate_deploy_instance", mutates=False, status="running")
+        append_step(manifest, "validate_deploy_instance_api", mutates=False, status="running")
+        manifest["validation"] = {
+            "status": "running",
+            "checks": [
+                "instance_running",
+                "region_matches",
+                "required_tags_match",
+            ],
+        }
         validate_deploy_instance(deploy_instance, required_tags=tags, region=region)
         manifest["validation"] = {
             "status": "succeeded",
@@ -146,7 +154,7 @@ def execute_deploy(
                 "required_tags_match",
             ],
         }
-        finish_step(manifest, "validate_deploy_instance")
+        finish_step(manifest, "validate_deploy_instance_api")
 
         if options.defer_cleanup:
             manifest["cleanup"] = {"status": "deferred", "deleted": [], "preserved": []}
@@ -176,16 +184,18 @@ def execute_deploy(
             except Exception:
                 mark_running_step_failed(manifest)
                 manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+        if manifest.get("validation", {}).get("status") == "running":
+            manifest["validation"]["status"] = "failed"
         raise DeployError("deploy --execute failed", manifest) from exc
 
 
 def validate_execute_options(options: DeployOptions) -> None:
     if len(options.regions) != 1:
-        raise DeployError("deploy --execute requires exactly one region")
+        raise DeployError("deploy --execute requires exactly one non-empty --region")
     if not options.image_id:
-        raise DeployError("deploy --execute requires --image-id")
+        raise DeployError("deploy --execute requires --image-id for the custom image to deploy")
     if not options.instance_type:
-        raise DeployError("deploy --execute requires --type")
+        raise DeployError("deploy --execute requires --type for the temporary deploy Linode")
 
 
 def cleanup_deploy_instance(
@@ -196,24 +206,48 @@ def cleanup_deploy_instance(
     preserve_instance: bool,
     required_tags: list[str],
 ) -> None:
-    append_step(manifest, "cleanup_deploy_instance", mutates=not preserve_instance, status="running")
+    can_delete = has_required_tags(deploy_instance, required_tags)
+    cleanup_action = "delete" if not preserve_instance and can_delete else "preserve"
+    append_step(
+        manifest,
+        "cleanup_deploy_instance",
+        mutates=cleanup_action == "delete",
+        status="running",
+        action=cleanup_action,
+    )
     cleanup = {"status": "not_started", "deleted": [], "preserved": []}
     if preserve_instance:
         cleanup["status"] = "preserved"
-        cleanup["preserved"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
-    elif has_required_tags(deploy_instance, required_tags):
+        cleanup["preserved"].append(
+            {"resource_type": "linode", "linode_id": deploy_instance.get("linode_id"), "reason": "requested"}
+        )
+    elif can_delete:
         client.delete_instance(required_int(deploy_instance.get("linode_id")))
         cleanup["status"] = "deleted"
-        cleanup["deleted"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
+        cleanup["deleted"].append(
+            {"resource_type": "linode", "linode_id": deploy_instance.get("linode_id"), "reason": "tag_match"}
+        )
     else:
-        cleanup["status"] = "skipped_tag_mismatch"
-        cleanup["preserved"].append({"resource_type": "linode", "linode_id": deploy_instance.get("linode_id")})
+        cleanup["status"] = "preserved"
+        cleanup["preserved"].append(
+            {"resource_type": "linode", "linode_id": deploy_instance.get("linode_id"), "reason": "tag_mismatch"}
+        )
     manifest["cleanup"] = cleanup
     finish_step(manifest, "cleanup_deploy_instance")
 
 
-def append_step(manifest: dict[str, Any], name: str, *, mutates: bool, status: str) -> None:
-    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+def append_step(
+    manifest: dict[str, Any],
+    name: str,
+    *,
+    mutates: bool,
+    status: str,
+    action: str | None = None,
+) -> None:
+    step = {"name": name, "mutates": mutates, "status": status}
+    if action is not None:
+        step["action"] = action
+    manifest["steps"].append(step)
 
 
 def finish_step(manifest: dict[str, Any], name: str) -> None:

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -87,7 +87,7 @@ def create_manifest(
     """Create a JSON-compatible manifest for a CLI command."""
     validate_mode(mode)
     if not regions and command != "cleanup":
-        raise ValueError("at least one region is required")
+        raise ValueError("at least one non-empty --region is required")
 
     created_at = format_timestamp(utc_now())
     manifest_run_id = run_id or f"run-{uuid4().hex[:12]}"

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -137,7 +137,7 @@ class CaptureExecutionTests(unittest.TestCase):
                 )
 
     def test_execute_requires_single_region(self) -> None:
-        with self.assertRaisesRegex(CaptureError, "exactly one region"):
+        with self.assertRaisesRegex(CaptureError, "exactly one non-empty --region"):
             capture_plan(
                 regions=["us-east", "us-west"],
                 run_id="run-test",
@@ -196,6 +196,7 @@ class CaptureExecutionTests(unittest.TestCase):
         self.assertEqual(manifest["capture_source"]["linode_id"], 123)
         self.assertEqual(manifest["custom_image"]["image_id"], "private/789")
         self.assertEqual(manifest["cleanup"]["status"], "deleted")
+        self.assertEqual(manifest["validation"]["status"], "succeeded")
 
     def test_execute_applies_required_tags_to_created_resources(self) -> None:
         client = FakeLinodeClient()
@@ -232,6 +233,8 @@ class CaptureExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [])
         self.assertEqual(manifest["cleanup"]["status"], "preserved")
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "requested")
+        self.assertEqual(manifest["steps"][-1]["action"], "preserve")
 
     def test_partial_failure_cleanup_skips_resource_missing_required_tags(self) -> None:
         client = FakeLinodeClient(missing_create_tags=True)
@@ -249,7 +252,8 @@ class CaptureExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [])
         self.assertIsNotNone(raised.exception.manifest)
-        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "skipped_tag_mismatch")
+        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "preserved")
+        self.assertEqual(raised.exception.manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
 
     def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
         manifest = capture_plan(

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -170,7 +170,7 @@ class CaptureDeployExecutionTests(unittest.TestCase):
                 )
 
     def test_execute_requires_single_region(self) -> None:
-        with self.assertRaisesRegex(CaptureDeployError, "exactly one region"):
+        with self.assertRaisesRegex(CaptureDeployError, "exactly one non-empty --region"):
             capture_deploy_plan(
                 regions=["us-east", "us-west"],
                 run_id="run-test",
@@ -214,6 +214,7 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         )
         self.assertEqual(manifest["status"], "succeeded")
         self.assertEqual(manifest["capture"]["custom_image"]["image_id"], "private/789")
+        self.assertEqual(manifest["capture"]["validation"]["status"], "succeeded")
         self.assertEqual(manifest["deploy"]["deploy_source"]["image_id"], "private/789")
         self.assertEqual(manifest["validation"]["status"], "succeeded")
         self.assertEqual(manifest["cleanup"]["status"], "completed")
@@ -253,6 +254,8 @@ class CaptureDeployExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [123])
         self.assertEqual(manifest["deploy"]["cleanup"]["status"], "preserved")
+        self.assertEqual(manifest["deploy"]["cleanup"]["preserved"][0]["reason"], "requested")
+        self.assertEqual(manifest["deploy"]["steps"][-1]["action"], "preserve")
 
     def test_cleanup_skips_deploy_resource_missing_current_run_tags(self) -> None:
         client = FakeLinodeClient(missing_deploy_tags=True)
@@ -270,7 +273,8 @@ class CaptureDeployExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [123])
         self.assertIsNotNone(raised.exception.manifest)
-        self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["status"], "skipped_tag_mismatch")
+        self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["status"], "preserved")
+        self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
 
     def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
         manifest = capture_deploy_plan(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -78,7 +78,15 @@ class CliTests(unittest.TestCase):
             main(["deploy", "--region", "us-east", "--execute", "--image-id", "private/789"])
 
         self.assertEqual(raised.exception.code, 2)
-        self.assertIn("--type", error.getvalue())
+        self.assertIn("--type for the temporary deploy Linode", error.getvalue())
+
+    def test_deploy_execute_requires_image_id_before_mutation(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["deploy", "--region", "us-east", "--execute", "--type", "g6-nanode-1"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--image-id for the custom image to deploy", error.getvalue())
 
     def test_capture_deploy_execute_requires_options_before_mutation(self) -> None:
         error = StringIO()

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -119,7 +119,7 @@ class DeployExecutionTests(unittest.TestCase):
                 )
 
     def test_execute_requires_single_region(self) -> None:
-        with self.assertRaisesRegex(DeployError, "exactly one region"):
+        with self.assertRaisesRegex(DeployError, "exactly one non-empty --region"):
             deploy_plan(
                 regions=["us-east", "us-west"],
                 run_id="run-test",
@@ -230,6 +230,8 @@ class DeployExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [])
         self.assertEqual(manifest["cleanup"]["status"], "preserved")
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "requested")
+        self.assertEqual(manifest["steps"][-1]["action"], "preserve")
 
     def test_partial_failure_cleanup_skips_resource_missing_required_tags(self) -> None:
         client = FakeLinodeClient(missing_create_tags=True)
@@ -247,7 +249,8 @@ class DeployExecutionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [])
         self.assertIsNotNone(raised.exception.manifest)
-        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "skipped_tag_mismatch")
+        self.assertEqual(raised.exception.manifest["cleanup"]["status"], "preserved")
+        self.assertEqual(raised.exception.manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
 
     def test_partial_failure_deletes_tagged_resource_by_default(self) -> None:
         client = FakeLinodeClient(status="offline")


### PR DESCRIPTION
## Summary
- Polishes manifest structure, cleanup representation, step naming, and CLI error text after M4.
- Clarifies validation boundaries, resource lifecycle, cleanup semantics, and top-level versus nested manifest sections in docs.
- Updates focused tests for representation-only manifest wording changes.

## Behavior
Execution flow, command flags, token handling, redaction, tag-scoped cleanup, and dry-run versus execute boundaries are unchanged.

## Consistency improvements
- Capture now reports a validation block like deploy and capture-deploy.
- Step names distinguish API preflight, API validation, phase execution, and temporary-resource cleanup more clearly.
- Cleanup preservation records explicit reasons such as requested, tag_mismatch, and deliverable.
- Capture-deploy documents intentional double preflight and combined versus nested resources and cleanup.

## Validation
- make check: passed; security-check passed and 63 unit tests passed.
- make security-check: passed.
