### PR TITLE
[codex] Add release Makefile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Add lightweight, human-gated Makefile support for tagged GitHub releases.
+
+## 0.1.0
+
+- First release candidate for the public-safe Linode Image Lab scaffold.
+- Includes dry-run-first planning, capture, deploy, capture-deploy, cleanup,
+  sanitized manifests, and repo validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@
 
 ## 0.1.0
 
-- First release candidate for the public-safe Linode Image Lab scaffold.
+- First public-safe release of Linode Image Lab.
 - Includes dry-run-first planning, capture, deploy, capture-deploy, cleanup,
   sanitized manifests, and repo validation.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 PYTHON ?= python3
 export PYTHONPATH := src
+RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
+RELEASE_TAG = v$(RELEASE_VERSION)
 
-.PHONY: check test security-check
+.PHONY: check test security-check check-gh-env release-notes release-check release-publish
 
 check: security-check test
 
@@ -10,3 +12,118 @@ test:
 
 security-check:
 	$(PYTHON) -m linode_image_lab.validation .
+
+check-gh-env:
+	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }
+	@gh auth status >/dev/null 2>&1 || { echo "Error: GitHub CLI authentication is required. Run 'gh auth login' and try again." >&2; exit 1; }
+
+release-notes:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release-publish VERSION=0.1.0" >&2; \
+		exit 1; \
+	fi
+	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must be X.Y.Z or vX.Y.Z." >&2; \
+		exit 1; \
+	fi
+	@awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md
+
+release-check: check-gh-env
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is required. Usage: make release-publish VERSION=0.1.0" >&2; \
+		exit 1; \
+	fi
+	@if ! printf '%s\n' '$(RELEASE_VERSION)' | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must be X.Y.Z or vX.Y.Z." >&2; \
+		exit 1; \
+	fi
+	@awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md >/dev/null
+	@if [ "$$(git branch --show-current)" != "main" ]; then \
+		echo "Error: release must run from main after the release PR is merged." >&2; \
+		exit 1; \
+	fi
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "Error: working tree must be clean before release." >&2; \
+		git status --short; \
+		exit 1; \
+	fi
+	@git fetch origin main >/dev/null
+	@if [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/main)" ]; then \
+		echo "Error: local main must match origin/main. Run 'git pull --ff-only origin main' and retry." >&2; \
+		exit 1; \
+	fi
+	@if git rev-parse --verify --quiet "refs/tags/$(RELEASE_TAG)" >/dev/null; then \
+		echo "Error: local tag $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	fi
+	@remote_tag_status=0; \
+	git ls-remote --exit-code --tags origin "refs/tags/$(RELEASE_TAG)" >/dev/null 2>&1 || remote_tag_status=$$?; \
+	if [ "$$remote_tag_status" -eq 0 ]; then \
+		echo "Error: remote tag $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	elif [ "$$remote_tag_status" -ne 2 ]; then \
+		echo "Error: unable to check remote tag $(RELEASE_TAG)." >&2; \
+		exit 1; \
+	fi
+	@release_view=$$(gh release view "$(RELEASE_TAG)" 2>&1 >/dev/null); \
+	release_status=$$?; \
+	if [ "$$release_status" -eq 0 ]; then \
+		echo "Error: GitHub release $(RELEASE_TAG) already exists." >&2; \
+		exit 1; \
+	elif ! printf '%s\n' "$$release_view" | grep -Eiq 'not found|could not find'; then \
+		echo "Error: unable to check GitHub release $(RELEASE_TAG): $$release_view" >&2; \
+		exit 1; \
+	fi
+	@echo "Release checks passed for $(RELEASE_TAG)."
+
+release-publish: release-check
+	@set -e; \
+	notes_file=$$(mktemp); \
+	trap 'rm -f "$$notes_file"' EXIT; \
+	awk -v version='$(RELEASE_VERSION)' '\
+		BEGIN { found = 0; printed = 0 } \
+		$$0 == "## " version { found = 1; next } \
+		found && /^## / { exit } \
+		found { print; if ($$0 !~ /^[[:space:]]*$$/) printed = 1 } \
+		END { \
+			if (!found) { \
+				printf "Error: CHANGELOG.md missing section ## %s.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+			if (!printed) { \
+				printf "Error: CHANGELOG.md section ## %s has no release notes.\n", version > "/dev/stderr"; \
+				exit 1; \
+			} \
+		}' CHANGELOG.md > "$$notes_file"; \
+	git tag -a "$(RELEASE_TAG)" -m "Release $(RELEASE_TAG)"; \
+	git push origin "$(RELEASE_TAG)"; \
+	gh release create "$(RELEASE_TAG)" --title "$(RELEASE_TAG)" --notes-file "$$notes_file"; \
+	echo "Published GitHub release $(RELEASE_TAG)."


### PR DESCRIPTION
## Summary

- Add lightweight Makefile release variables and human-gated GitHub release targets based on the knowledge-adapters pattern.
- Add an initial CHANGELOG.md with Unreleased and 0.1.0 sections so release notes can be extracted before the first tagged release.
- Keep publishing manual: release-publish requires release-check, creates an annotated tag, pushes the tag, and creates the GitHub release from changelog notes.

## Validation

- `make check`
- `make release-notes VERSION=0.1.0`

## Release safety

No release was published. `make release-publish` was not run.