### PR TITLE
[codex] Fix v0.1.0 readiness blockers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,10 @@ Repo-local rules take precedence only for repo-specific behavior.
   `capture --execute`; default behavior remains non-mutating.
 - M3 permits explicit single-region deploy execution only through
   `deploy --execute`; default behavior remains non-mutating.
-- Do not add capture-deploy, multi-region execution, or additional real Linode
-  mutation behavior until a later milestone explicitly asks for it.
+- M4 permits explicit single-region capture-deploy execution only through
+  `capture-deploy --execute`; default behavior remains non-mutating.
+- Do not add multi-region execution or additional real Linode mutation behavior
+  until a later milestone explicitly asks for it.
 
 ## Public-Safe Boundary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
-- Add lightweight, human-gated Makefile support for tagged GitHub releases.
+- None.
 
 ## 0.1.0
 
 - First public-safe release of Linode Image Lab.
 - Includes dry-run-first planning, capture, deploy, capture-deploy, cleanup,
   sanitized manifests, and repo validation.
+- Adds lightweight, human-gated Makefile support for tagged GitHub releases.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -27,6 +27,6 @@ Before opening a PR:
 - confirm fixtures are sanitized,
 - confirm dry-run commands remain non-mutating,
 - confirm real mutation remains limited to explicit `capture --execute` and
-  `deploy --execute`,
+  `deploy --execute`, and `capture-deploy --execute`,
 - confirm cleanup only targets resources with complete matching tags,
 - confirm docs describe behavior without private context.

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -76,7 +76,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep the temporary deploy validation Linode after execution.",
     )
 
-    cleanup = subparsers.add_parser("cleanup", help="Placeholder cleanup command.")
+    cleanup = subparsers.add_parser("cleanup", help="Preview tag-scoped cleanup selection.")
     cleanup.add_argument("--run-id", help="Optional run id to include in the cleanup preview.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 

--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -49,17 +49,32 @@ TEXT_SUFFIXES = {
     ".sh",
     ".mk",
 }
-SKIP_DIRS = {".git", ".mypy_cache", ".pytest_cache", "__pycache__"}
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "htmlcov",
+}
 FIXTURE_ROOT = Path("tests/fixtures")
 SANITIZED_FIXTURE_ROOT = FIXTURE_ROOT / "sanitized"
 
 
-def iter_text_files(root: Path) -> list[Path]:
+def should_skip_local_path(path: Path) -> bool:
+    return any(part in SKIP_DIRS or part.endswith(".egg-info") for part in path.parts)
+
+
+def iter_local_files(root: Path) -> list[Path]:
     files: list[Path] = []
     for path in root.rglob("*"):
-        if any(part in SKIP_DIRS for part in path.parts):
+        if should_skip_local_path(path):
             continue
-        if path.is_file() and (path.suffix in TEXT_SUFFIXES or path.name == "Makefile"):
+        if path.is_file():
             files.append(path)
     return files
 
@@ -68,9 +83,9 @@ def is_text_path(path: Path) -> bool:
     return path.suffix in TEXT_SUFFIXES or path.name == "Makefile"
 
 
-def iter_tracked_text_files(root: Path) -> list[Path]:
+def iter_scanned_files(root: Path) -> list[Path]:
     if not (root / ".git").exists():
-        return iter_text_files(root)
+        return iter_local_files(root)
 
     result = subprocess.run(
         ["git", "-C", str(root), "ls-files", "-z"],
@@ -79,16 +94,18 @@ def iter_tracked_text_files(root: Path) -> list[Path]:
         stderr=subprocess.DEVNULL,
     )
     if result.returncode != 0:
-        return iter_text_files(root)
+        return iter_local_files(root)
 
     files: list[Path] = []
     for name in result.stdout.decode("utf-8").split("\0"):
         if not name:
             continue
-        path = Path(name)
-        if is_text_path(path):
-            files.append(root / path)
+        files.append(root / Path(name))
     return files
+
+
+def iter_scanned_text_files(root: Path) -> list[Path]:
+    return [path for path in iter_scanned_files(root) if is_text_path(path)]
 
 
 def is_under(path: Path, parent: Path) -> bool:
@@ -96,14 +113,12 @@ def is_under(path: Path, parent: Path) -> bool:
 
 
 def scan_fixture_placement(root: Path) -> list[str]:
-    fixture_root = root / FIXTURE_ROOT
     sanitized_root = root / SANITIZED_FIXTURE_ROOT
-    if not fixture_root.exists():
-        return []
 
     findings: list[str] = []
-    for path in fixture_root.rglob("*"):
-        if path.is_file() and not is_under(path, sanitized_root):
+    for path in iter_scanned_files(root):
+        relative_path = path.relative_to(root)
+        if is_under(relative_path, FIXTURE_ROOT) and not is_under(path, sanitized_root):
             relative = path.relative_to(root)
             findings.append(f"{relative}: fixture files must live under {SANITIZED_FIXTURE_ROOT}/")
     return findings
@@ -111,7 +126,7 @@ def scan_fixture_placement(root: Path) -> list[str]:
 
 def scan_public_safety(root: Path) -> list[str]:
     findings = scan_fixture_placement(root)
-    for path in iter_text_files(root):
+    for path in iter_scanned_text_files(root):
         text = path.read_text(encoding="utf-8")
         relative = path.relative_to(root)
         lower_text = text.lower()
@@ -135,7 +150,7 @@ def scan_public_safety(root: Path) -> list[str]:
 
 def scan_terminology_drift(root: Path) -> list[str]:
     findings: list[str] = []
-    for path in iter_tracked_text_files(root):
+    for path in iter_scanned_text_files(root):
         if not path.exists():
             continue
         text = path.read_text(encoding="utf-8")

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -63,6 +64,35 @@ class ValidationTests(unittest.TestCase):
             findings = scan_public_safety(root)
 
         self.assertEqual(findings, [])
+
+    def test_skips_local_install_artifacts_without_git(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / ".venv" / "lib" / "dependency.py"
+            path.parent.mkdir(parents=True)
+            email_like = "person" + "@" + "example.com"
+            path.write_text(f"maintainer = '{email_like}'\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, [])
+
+    def test_git_checkout_scans_tracked_files_not_ignored_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            email_like = "person" + "@" + "example.com"
+            readme = root / "README.md"
+            readme.write_text(f"contact {email_like}\n", encoding="utf-8")
+            venv_file = root / ".venv" / "lib" / "dependency.py"
+            venv_file.parent.mkdir(parents=True)
+            private_url = "http://" + "127.0.0.1:8000"
+            venv_file.write_text(f"url = '{private_url}'\n", encoding="utf-8")
+            subprocess.run(["git", "add", "README.md"], cwd=root, check=True, stdout=subprocess.DEVNULL)
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, ["README.md: email-like value detected"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Make the public-safety scanner use tracked files in Git checkouts while skipping ignored local install/build artifacts in non-Git trees.
- Add focused validation tests for `.venv/` skip behavior and tracked-file scanning.
- Refresh M4 release-readiness wording in AGENTS/docs/changelog and cleanup CLI help.

## Release Blocker Fixed

`make check` now passes in an editable-install workspace with `.venv/` present, without weakening scanning for tracked repository files.

## Validation

- `make check` ✅
- `make security-check` ✅
- `make release-notes VERSION=0.1.0` ✅
- `. .venv/bin/activate && make check` ✅
- `. .venv/bin/activate && linode-image-lab --help` ✅
- `git diff --check` ✅
- `make release-check VERSION=0.1.0` was attempted with GitHub CLI auth available and stopped at the expected branch gate: release checks must run from `main` after the PR is merged.

## Release Safety

No tag was created, no GitHub release was created, and `make release-publish` was not run.
