### PR TITLE
[codex] Codify execution model boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,18 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Do not add multi-region execution or additional real Linode mutation behavior
   until a later milestone explicitly asks for it.
 
+## Execution Model Boundary
+
+- Linode Image Lab is an ephemeral validation workflow tool, not durable
+  infrastructure ownership.
+- Configuration may provide execution defaults only.
+- Do not introduce desired-state management concepts.
+- Do not add state files, drift reconciliation, resource graphs, dependency
+  planning, or Terraform-like behavior.
+- Future multi-region support must remain execution fan-out for disposable
+  validation runs, not infrastructure ownership.
+- Keep cleanup and validation first-class in any execution path.
+
 ## Public-Safe Boundary
 
 - Treat every file as public.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ M4 remains intentionally conservative:
 - `cleanup` is first-class and independently runnable.
 - Manifest schema, rediscoverable tags, and cleanup selection are the foundation.
 
+## Execution Model Boundary
+
+Configuration will provide execution defaults for disposable validation runs.
+Runs are ephemeral validation workflows: they create, validate, and clean up
+temporary resources unless an explicit preservation flag keeps a deliverable.
+Linode Image Lab does not manage durable desired state, does not own long-lived
+infrastructure, and does not perform drift reconciliation. Cleanup and
+validation remain first-class parts of the workflow.
+
 ## Independence and Intent
 
 This is a personal, independent project. It is not affiliated with any employer

--- a/docs/design.md
+++ b/docs/design.md
@@ -17,7 +17,16 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 - No implicit Linode API mutations.
 - No multi-region execution, GitHub Actions mutation, or external scheduler
   integration.
+- No infrastructure ownership or planning model.
 - CI exists to run `make check`.
+
+## Execution Model Boundary
+
+Future configuration and future multi-region support are execution defaults for
+disposable validation runs. They must not turn the tool into infrastructure
+ownership. Runs remain ephemeral validation workflows with explicit mutation
+entrypoints, provider/API-level validation, tagged temporary resources, and
+cleanup as a first-class outcome.
 
 ## Components
 

--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -22,6 +22,23 @@ LEGACY_WORKFLOW_TERMS = tuple(
         ("fr", "eeze-", "th", "aw"),
     )
 )
+EXECUTION_MODEL_DRIFT_PATTERNS = tuple(
+    re.compile(pattern, re.I)
+    for pattern in (
+        r"\bdes" + r"ired[- ]sta" + r"te\b",
+        r"\bsta" + r"te[- ]files?\b",
+        r"\bdri" + r"ft[- ]recon" + r"ciliation\b",
+        r"\bres" + r"ource[- ]graphs?\b",
+        r"\bdep" + r"endency[- ]planning\b",
+        r"\bter" + r"raform\b",
+    )
+)
+EXECUTION_MODEL_SECTION = "Execution Model Boundary"
+EXECUTION_MODEL_SECTION_FILES = {
+    Path("AGENTS.md"),
+    Path("README.md"),
+    Path("docs/design.md"),
+}
 EMAIL_RE = re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.I)
 PRIVATE_URL_RE = re.compile(
     r"https?://(?:localhost|127\.0\.0\.1|10\.|192\.168\.|172\.(?:1[6-9]|2[0-9]|3[0-1])\.|[^/\s]+\.internal\b|[^/\s]+\.corp\b)",
@@ -159,7 +176,38 @@ def scan_terminology_drift(root: Path) -> list[str]:
             lower_line = line.lower()
             if any(term in lower_line for term in LEGACY_WORKFLOW_TERMS):
                 findings.append(f"{relative}:{line_number}: legacy image workflow terminology detected")
+            if has_execution_model_drift(line) and not is_allowed_execution_model_section(relative, line_number, text):
+                findings.append(
+                    f"{relative}:{line_number}: out-of-scope infrastructure-management terminology detected"
+                )
     return findings
+
+
+def has_execution_model_drift(line: str) -> bool:
+    return any(pattern.search(line) for pattern in EXECUTION_MODEL_DRIFT_PATTERNS)
+
+
+def is_allowed_execution_model_section(relative: Path, line_number: int, text: str) -> bool:
+    if relative not in EXECUTION_MODEL_SECTION_FILES:
+        return False
+
+    active_heading_level: int | None = None
+    in_allowed_section = False
+    for current_line_number, line in enumerate(text.splitlines(), start=1):
+        heading = re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
+        if heading:
+            level = len(heading.group(1))
+            title = heading.group(2)
+            if title == EXECUTION_MODEL_SECTION:
+                active_heading_level = level
+                in_allowed_section = True
+            elif active_heading_level is not None and level <= active_heading_level:
+                in_allowed_section = False
+                active_heading_level = None
+        if current_line_number == line_number:
+            return in_allowed_section
+
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -65,6 +65,70 @@ class ValidationTests(unittest.TestCase):
 
         self.assertEqual(findings, [])
 
+    def test_reports_execution_model_drift_terms_outside_boundary_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "README.md"
+            phrase = "desired" + " state"
+            path.write_text(f"Add {phrase} management later.\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(
+            findings,
+            ["README.md:1: out-of-scope infrastructure-management terminology detected"],
+        )
+
+    def test_allows_execution_model_drift_terms_inside_boundary_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "README.md"
+            phrase = "state" + " file"
+            path.write_text(
+                "# Title\n\n"
+                "## Execution Model Boundary\n\n"
+                f"Do not add a {phrase}.\n\n"
+                "## Commands\n\n"
+                "capture remains explicit.\n",
+                encoding="utf-8",
+            )
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, [])
+
+    def test_reports_execution_model_drift_terms_after_boundary_section(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "README.md"
+            phrase = "resource" + " graph"
+            path.write_text(
+                "# Title\n\n"
+                "## Execution Model Boundary\n\n"
+                "Boundary terms are documented here.\n\n"
+                "## Commands\n\n"
+                f"Build a {phrase} later.\n",
+                encoding="utf-8",
+            )
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(
+            findings,
+            ["README.md:9: out-of-scope infrastructure-management terminology detected"],
+        )
+
+    def test_allows_resource_state_status_contexts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            path = root / "docs" / "capture.md"
+            path.parent.mkdir(parents=True)
+            path.write_text("Validate provider resource state and running status.\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, [])
+
     def test_skips_local_install_artifacts_without_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary

- Add explicit execution-model boundary documentation to README and design docs.
- Add repo-local AGENTS guidance keeping config and future multi-region work scoped to execution defaults for disposable validation runs.
- Extend the public-safety validation with a focused terminology guard for clearly out-of-scope infrastructure-management phrases outside documented boundary sections.

## Boundary codified

Linode Image Lab is documented as an ephemeral validation workflow tool. Configuration may provide execution defaults, but the tool does not manage durable desired state, own long-lived infrastructure, or perform drift reconciliation. Cleanup and validation remain first-class parts of every execution path.

## Validation guard

Added. The guard is intentionally narrow and checks only explicit desired-state infrastructure-management phrases, while allowing deliberate explanatory usage inside `Execution Model Boundary` sections in `README.md`, `docs/design.md`, and `AGENTS.md`. It does not block harmless wording such as provider resource state/status.

## Validation

- `make security-check` passed.
- `make check` passed: 69 unit tests.

Runtime behavior is unchanged; the only enforcement change is the local validation/security-check terminology guard.