### PR TITLE
[codex] Add config-backed execution defaults (M5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ LINODE_TOKEN='op://Private/Linode API Token/credential' op run -- \
 
 ## Config Defaults
 
-Pass `--config` before the command to load optional TOML execution defaults.
-Config values fill omitted CLI flags; explicit CLI flags always win.
+Pass `--config` before or after the command to load optional TOML execution
+defaults. Config values fill omitted CLI flags; explicit CLI flags always win.
 
 ```sh
 linode-image-lab --config examples/config/capture-deploy-smoke.toml capture-deploy
-linode-image-lab --config examples/config/capture-deploy-smoke.toml capture-deploy --execute
+linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
 ```
 
 Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,

--- a/README.md
+++ b/README.md
@@ -75,11 +75,32 @@ LINODE_TOKEN='op://Private/Linode API Token/credential' op run -- \
     --execute
 ```
 
+## Config Defaults
+
+Pass `--config` before the command to load optional TOML execution defaults.
+Config values fill omitted CLI flags; explicit CLI flags always win.
+
+```sh
+linode-image-lab --config examples/config/capture-deploy-smoke.toml capture-deploy
+linode-image-lab --config examples/config/capture-deploy-smoke.toml capture-deploy --execute
+```
+
+Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
+`[deploy]`, `[capture-deploy]`, and `[cleanup]` tables. Supported values are
+`region` or `regions`, `ttl`, `source_image`, `image_id`, and `type`, depending
+on the command.
+
+Config is only for execution defaults. It cannot contain `LINODE_TOKEN`, token
+values, passwords, SSH keys, cloud-init data, `execute`, preservation flags, or
+run id fields. `--execute` must still be passed explicitly, and `LINODE_TOKEN`
+must still come from the environment or approved environment injection.
+
 ## Behavior Clarifications
 
 - All commands are dry-run by default.
 - `--execute` enables real Linode API mutations for `capture`, `deploy`, and
   `capture-deploy`.
+- Config values only fill omitted command options; CLI flags override config.
 - Execute runs use temporary resources and clean them up automatically unless a
   preservation flag is used.
 - Custom images are preserved as deliverables.

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -72,6 +72,16 @@ LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli depl
   --run-id "run-m3-smoke"
 ```
 
+With config-backed defaults:
+
+```sh
+LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli \
+  --config examples/config/deploy-existing-image.toml \
+  deploy \
+  --execute \
+  --run-id "run-m3-smoke"
+```
+
 ## Capture-Deploy
 
 The capture-deploy flow validates the end-to-end path by capturing a custom
@@ -113,6 +123,20 @@ LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli capt
   --type g6-nanode-1 \
   --run-id "run-m4-smoke"
 ```
+
+With config-backed defaults:
+
+```sh
+LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli \
+  --config examples/config/capture-deploy-smoke.toml \
+  capture-deploy \
+  --execute \
+  --run-id "run-m4-smoke"
+```
+
+Config defaults can replace omitted `--region`, `--source-image`,
+`--image-id`, `--type`, and `--ttl` values. They do not replace `--execute`,
+preservation flags, run ids, or environment-based token injection.
 
 ## Cleanup
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -31,6 +31,7 @@ cleanup as a first-class outcome.
 ## Components
 
 - `cli.py` owns command parsing and JSON output.
+- `config.py` owns explicit TOML config loading and safe default resolution.
 - `capture.py` owns dry-run capture manifests and execute-mode orchestration.
 - `deploy.py` owns dry-run deploy manifests and execute-mode orchestration.
 - `capture_deploy.py` owns the combined capture-deploy execute orchestration.
@@ -60,6 +61,30 @@ nested cleanup blocks preserve phase-specific status. Internal manifests may
 carry provider resource identifiers required for cleanup and debugging. Normal
 stdout uses sanitized serialization, which redacts provider identifiers before
 printing.
+
+## Config Defaults
+
+Config is opt-in through `--config PATH` and uses TOML `schema_version = 1`.
+The config file can provide execution defaults in `[defaults]`, `[capture]`,
+`[deploy]`, `[capture-deploy]`, and `[cleanup]` tables. CLI flags take
+precedence over command-specific config, command-specific config takes
+precedence over `[defaults]`, and existing generated defaults remain last.
+
+Supported config values are intentionally narrow:
+
+- `region` or `regions`,
+- `ttl`,
+- `source_image` for capture and capture-deploy,
+- `image_id` for deploy,
+- `type` for capture, deploy, and capture-deploy.
+
+`--execute`, preservation flags, run id fields, image labels, tokens,
+passwords, SSH keys, root passwords, and cloud-init or user-data fields are not
+configurable. Unknown keys and secret-like keys fail before command execution.
+
+Multi-region config is accepted for dry-run manifests. Execute mode still
+requires exactly one effective region and fails before token lookup when config
+or CLI values resolve to multiple regions.
 
 ## Capture Execution Boundary
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -64,11 +64,12 @@ printing.
 
 ## Config Defaults
 
-Config is opt-in through `--config PATH` and uses TOML `schema_version = 1`.
-The config file can provide execution defaults in `[defaults]`, `[capture]`,
-`[deploy]`, `[capture-deploy]`, and `[cleanup]` tables. CLI flags take
-precedence over command-specific config, command-specific config takes
-precedence over `[defaults]`, and existing generated defaults remain last.
+Config is opt-in through `--config PATH`, either before or after the command,
+and uses TOML `schema_version = 1`. The config file can provide execution
+defaults in `[defaults]`, `[capture]`, `[deploy]`, `[capture-deploy]`, and
+`[cleanup]` tables. CLI flags take precedence over command-specific config,
+command-specific config takes precedence over `[defaults]`, and existing
+generated defaults remain last.
 
 Supported config values are intentionally narrow:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,9 +10,25 @@ non-mutating; capture and deploy execution require explicit opt-in.
 - The CLI reads `LINODE_TOKEN` only for `capture --execute`,
   `deploy --execute`, or `capture-deploy --execute`.
 - Dry-run commands do not read token values.
+- Config files cannot provide `LINODE_TOKEN` or any token value. They only fill
+  non-secret execution defaults after explicit `--config PATH`.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
 - Normal stdout and stderr must not print tokens, authorization headers, root
   passwords, SSH keys, cloud-init secrets, or provider resource identifiers.
+
+## Config Safety
+
+Config files are parsed with the Python standard library TOML parser and must
+declare `schema_version = 1`. Unknown keys fail, and secret-like keys fail even
+when they appear in a table that is not used by the selected command.
+
+Supported config values are limited to region defaults, TTL, source image,
+existing custom image id, and Linode type. Config cannot set `--execute`,
+preservation flags, run ids, image labels, tokens, passwords, SSH keys, root
+passwords, cloud-init data, or user-data.
+
+Config loading and validation happen before token lookup. Execute mode still
+requires `LINODE_TOKEN` from the environment or approved environment injection.
 
 ## Execute Permissions
 

--- a/examples/config/capture-deploy-smoke.toml
+++ b/examples/config/capture-deploy-smoke.toml
@@ -1,0 +1,9 @@
+schema_version = 1
+
+[defaults]
+region = "us-east"
+ttl = "2030-01-01T00:00:00Z"
+
+[capture-deploy]
+source_image = "linode/alpine3.23"
+type = "g6-nanode-1"

--- a/examples/config/deploy-existing-image.toml
+++ b/examples/config/deploy-existing-image.toml
@@ -1,0 +1,9 @@
+schema_version = 1
+
+[defaults]
+region = "us-east"
+ttl = "2030-01-01T00:00:00Z"
+
+[deploy]
+image_id = "private/example-custom-image"
+type = "g6-nanode-1"

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -9,6 +9,7 @@ from typing import Any
 from .cleanup import select_cleanup_candidates
 from .capture import CaptureError, capture_plan
 from .capture_deploy import CaptureDeployError, capture_deploy_plan
+from .config import ConfigError, command_defaults, load_config
 from .deploy import DeployError, deploy_plan
 from .manifest import create_manifest, serialize_manifest
 from .regions import parse_regions
@@ -18,7 +19,7 @@ def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
     parser.add_argument(
         "--region",
         action="append",
-        required=required,
+        required=False,
         help="Linode region id. May be repeated or comma-separated.",
     )
     parser.add_argument("--run-id", help="Optional run id for deterministic planning.")
@@ -27,6 +28,7 @@ def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="linode-image-lab")
+    parser.add_argument("--config", help="Optional TOML file with execution defaults.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     plan = subparsers.add_parser("plan", help="Emit a dry-run manifest preview.")
@@ -81,6 +83,40 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
     return parser
+
+
+def resolve_config_defaults(args: argparse.Namespace) -> None:
+    config = load_config(args.config)
+    defaults = command_defaults(config, args.command)
+
+    if args.command in {"plan", "capture", "deploy", "capture-deploy"}:
+        if args.region is None:
+            args.region = config_regions(defaults)
+        if not parse_regions(args.region):
+            raise ValueError("at least one non-empty --region is required")
+
+    if args.ttl is None and "ttl" in defaults:
+        args.ttl = defaults["ttl"]
+
+    if args.command in {"capture", "capture-deploy"}:
+        if args.source_image is None and "source_image" in defaults:
+            args.source_image = defaults["source_image"]
+        if args.instance_type is None and "type" in defaults:
+            args.instance_type = defaults["type"]
+
+    if args.command == "deploy":
+        if args.image_id is None and "image_id" in defaults:
+            args.image_id = defaults["image_id"]
+        if args.instance_type is None and "type" in defaults:
+            args.instance_type = defaults["type"]
+
+
+def config_regions(defaults: dict[str, Any]) -> list[str] | None:
+    if "regions" in defaults:
+        return list(defaults["regions"])
+    if "region" in defaults:
+        return [defaults["region"]]
+    return None
 
 
 def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
@@ -150,6 +186,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        resolve_config_defaults(args)
         manifest = command_manifest(args)
     except CaptureError as exc:
         if exc.manifest is not None:
@@ -169,7 +206,7 @@ def main(argv: list[str] | None = None) -> int:
             sys.stderr.write("capture-deploy --execute failed\n")
             return 1
         parser.error(str(exc))
-    except ValueError as exc:
+    except (ConfigError, ValueError) as exc:
         parser.error(str(exc))
     sys.stdout.write(serialize_manifest(manifest))
     return 0

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -15,6 +15,14 @@ from .manifest import create_manifest, serialize_manifest
 from .regions import parse_regions
 
 
+def add_config_arg(parser: argparse.ArgumentParser, *, dest: str) -> None:
+    parser.add_argument(
+        "--config",
+        dest=dest,
+        help="Optional TOML file with execution defaults.",
+    )
+
+
 def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
     parser.add_argument(
         "--region",
@@ -28,10 +36,11 @@ def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="linode-image-lab")
-    parser.add_argument("--config", help="Optional TOML file with execution defaults.")
+    add_config_arg(parser, dest="global_config")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     plan = subparsers.add_parser("plan", help="Emit a dry-run manifest preview.")
+    add_config_arg(plan, dest="command_config")
     add_region_args(plan, required=True)
     plan.add_argument(
         "--mode",
@@ -41,6 +50,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     capture = subparsers.add_parser("capture", help="Plan or execute a single-region capture.")
+    add_config_arg(capture, dest="command_config")
     add_region_args(capture, required=True)
     capture.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
     capture.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
@@ -53,6 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     deploy = subparsers.add_parser("deploy", help="Plan or execute a single-region deploy.")
+    add_config_arg(deploy, dest="command_config")
     add_region_args(deploy, required=True)
     deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
     deploy.add_argument("--image-id", help="Custom image id for the temporary deploy Linode.")
@@ -64,6 +75,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     capture_deploy = subparsers.add_parser("capture-deploy", help="Plan or execute capture plus deploy validation.")
+    add_config_arg(capture_deploy, dest="command_config")
     add_region_args(capture_deploy, required=True)
     capture_deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
     capture_deploy.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
@@ -79,6 +91,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
 
     cleanup = subparsers.add_parser("cleanup", help="Preview tag-scoped cleanup selection.")
+    add_config_arg(cleanup, dest="command_config")
     cleanup.add_argument("--run-id", help="Optional run id to include in the cleanup preview.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
@@ -86,7 +99,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def resolve_config_defaults(args: argparse.Namespace) -> None:
-    config = load_config(args.config)
+    config = load_config(config_path(args))
     defaults = command_defaults(config, args.command)
 
     if args.command in {"plan", "capture", "deploy", "capture-deploy"}:
@@ -109,6 +122,14 @@ def resolve_config_defaults(args: argparse.Namespace) -> None:
             args.image_id = defaults["image_id"]
         if args.instance_type is None and "type" in defaults:
             args.instance_type = defaults["type"]
+
+
+def config_path(args: argparse.Namespace) -> str | None:
+    global_config = getattr(args, "global_config", None)
+    command_config = getattr(args, "command_config", None)
+    if global_config is not None and command_config is not None:
+        raise ValueError("provide --config either before or after the command, not both")
+    return command_config or global_config
 
 
 def config_regions(defaults: dict[str, Any]) -> list[str] | None:

--- a/src/linode_image_lab/config.py
+++ b/src/linode_image_lab/config.py
@@ -1,0 +1,142 @@
+"""TOML config loading for CLI execution defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+import tomllib
+
+
+class ConfigError(ValueError):
+    """Raised when config cannot safely provide execution defaults."""
+
+
+SCHEMA_VERSION = 1
+
+ROOT_KEYS = {
+    "schema_version",
+    "defaults",
+    "capture",
+    "deploy",
+    "capture-deploy",
+    "cleanup",
+}
+TABLE_FIELDS = {
+    "defaults": {"region", "regions", "ttl"},
+    "capture": {"region", "regions", "source_image", "type", "ttl"},
+    "deploy": {"region", "regions", "image_id", "type", "ttl"},
+    "capture-deploy": {"region", "regions", "source_image", "type", "ttl"},
+    "cleanup": {"ttl"},
+}
+COMMAND_TABLES = {"capture", "deploy", "capture-deploy", "cleanup"}
+PROHIBITED_KEYS = {
+    "execute",
+    "image-label",
+    "image_label",
+    "preserve-instance",
+    "preserve-source",
+    "preserve_instance",
+    "preserve_source",
+    "run-id",
+    "run-id-prefix",
+    "run_id",
+    "run_id_prefix",
+}
+SECRET_KEY_FRAGMENTS = (
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "ssh_key",
+    "sshkey",
+    "private_key",
+    "privatekey",
+    "root_password",
+    "rootpassword",
+    "cloud_init",
+    "cloudinit",
+    "user_data",
+    "userdata",
+    "authorized_keys",
+    "authorizedkeys",
+)
+
+
+def load_config(path: str | None) -> dict[str, Any]:
+    """Load and validate an optional TOML config file."""
+    if path is None:
+        return {}
+
+    config_path = Path(path)
+    try:
+        with config_path.open("rb") as handle:
+            raw_config = tomllib.load(handle)
+    except FileNotFoundError as exc:
+        raise ConfigError(f"config file not found: {path}") from exc
+    except OSError as exc:
+        raise ConfigError(f"could not read config file: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise ConfigError(f"invalid TOML config: {exc}") from exc
+
+    validate_config(raw_config)
+    return raw_config
+
+
+def validate_config(config: dict[str, Any]) -> None:
+    schema_version = config.get("schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise ConfigError("config schema_version must be 1")
+
+    for key, value in config.items():
+        validate_key_is_safe(key, location="root")
+        if key not in ROOT_KEYS:
+            raise ConfigError(f"unknown config key: {key}")
+        if key == "schema_version":
+            continue
+        if not isinstance(value, dict):
+            raise ConfigError(f"config [{key}] must be a table")
+        validate_table(key, value)
+
+
+def validate_table(table: str, values: dict[str, Any]) -> None:
+    allowed = TABLE_FIELDS[table]
+    if "region" in values and "regions" in values:
+        raise ConfigError(f"config [{table}] cannot set both region and regions")
+
+    for key, value in values.items():
+        validate_key_is_safe(key, location=f"[{table}]")
+        if key not in allowed:
+            raise ConfigError(f"unknown config key in [{table}]: {key}")
+        validate_value(table, key, value)
+
+
+def validate_key_is_safe(key: str, *, location: str) -> None:
+    normalized = key.lower().replace("-", "_")
+    if normalized in {value.replace("-", "_") for value in PROHIBITED_KEYS}:
+        raise ConfigError(f"config {location} key is not supported: {key}")
+    if any(fragment in normalized for fragment in SECRET_KEY_FRAGMENTS):
+        raise ConfigError(f"config {location} key must not contain secrets: {key}")
+
+
+def validate_value(table: str, key: str, value: Any) -> None:
+    if key == "regions":
+        if not isinstance(value, list) or not value:
+            raise ConfigError(f"config [{table}].regions must be a non-empty list of strings")
+        if not all(isinstance(region, str) and region.strip() for region in value):
+            raise ConfigError(f"config [{table}].regions must be a non-empty list of strings")
+        return
+
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"config [{table}].{key} must be a non-empty string")
+
+
+def command_defaults(config: dict[str, Any], command: str) -> dict[str, Any]:
+    """Return defaults merged as [defaults] then the command-specific table."""
+    if not config:
+        return {}
+
+    values: dict[str, Any] = dict(config.get("defaults", {}))
+    if command in COMMAND_TABLES:
+        values.update(config.get(command, {}))
+    return values

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
 
 from linode_image_lab.cli import main
 
@@ -95,6 +99,197 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--type", error.getvalue())
+
+    def test_missing_region_without_config_still_fails(self) -> None:
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("at least one non-empty --region is required", error.getvalue())
+
+    def test_config_fills_capture_deploy_defaults(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            ttl = "2030-01-01T00:00:00Z"
+
+            [capture-deploy]
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(["--config", config_path, "capture-deploy"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["regions"], ["us-east"])
+        self.assertEqual(payload["ttl"], "2030-01-01T00:00:00Z")
+
+    def test_cli_values_override_config_defaults(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            ttl = "2030-01-01T00:00:00Z"
+
+            [deploy]
+            image_id = "private/example-custom-image"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(
+                [
+                    "--config",
+                    config_path,
+                    "deploy",
+                    "--region",
+                    "us-west",
+                    "--ttl",
+                    "2031-01-01T00:00:00Z",
+                ]
+            )
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["regions"], ["us-west"])
+        self.assertEqual(payload["ttl"], "2031-01-01T00:00:00Z")
+
+    def test_unknown_config_key_fails_clearly(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            unexpected = "value"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", config_path, "capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("unknown config key in [defaults]: unexpected", error.getvalue())
+
+    def test_secret_like_config_key_fails_clearly(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            LINODE_TOKEN = "not-used"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", config_path, "capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("must not contain secrets", error.getvalue())
+
+    def test_execute_in_config_is_rejected(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture]
+            region = "us-east"
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            execute = "true"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", config_path, "capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("key is not supported: execute", error.getvalue())
+
+    def test_config_never_satisfies_linode_token(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [deploy]
+            region = "us-east"
+            image_id = "private/example-custom-image"
+            type = "g6-nanode-1"
+            """
+        )
+
+        error = StringIO()
+        with patch.dict(os.environ, {}, clear=True):
+            with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+                main(["--config", config_path, "deploy", "--execute"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("LINODE_TOKEN is required for deploy --execute", error.getvalue())
+
+    def test_multi_region_config_is_accepted_for_dry_run(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture]
+            regions = ["us-east", "us-west"]
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(["--config", config_path, "capture"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["regions"], ["us-east", "us-west"])
+
+    def test_multi_region_config_execute_fails_before_token_lookup(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture-deploy]
+            regions = ["us-east", "us-west"]
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        error = StringIO()
+        with patch.dict(os.environ, {}, clear=True):
+            with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+                main(["--config", config_path, "capture-deploy", "--execute"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("exactly one non-empty --region", error.getvalue())
+        self.assertNotIn("LINODE_TOKEN", error.getvalue())
+
+    def write_config(self, text: str) -> str:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        path = Path(directory.name) / "lab.toml"
+        path.write_text(text, encoding="utf-8")
+        return str(path)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -108,7 +108,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("at least one non-empty --region is required", error.getvalue())
 
-    def test_config_fills_capture_deploy_defaults(self) -> None:
+    def test_global_config_before_subcommand_fills_capture_deploy_defaults(self) -> None:
         config_path = self.write_config(
             """
             schema_version = 1
@@ -132,6 +132,56 @@ class CliTests(unittest.TestCase):
         self.assertTrue(payload["dry_run"])
         self.assertEqual(payload["regions"], ["us-east"])
         self.assertEqual(payload["ttl"], "2030-01-01T00:00:00Z")
+
+    def test_command_local_config_after_subcommand_fills_capture_deploy_defaults(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            ttl = "2030-01-01T00:00:00Z"
+
+            [capture-deploy]
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(["capture-deploy", "--config", config_path])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["regions"], ["us-east"])
+        self.assertEqual(payload["ttl"], "2030-01-01T00:00:00Z")
+
+    def test_duplicate_global_and_command_local_config_fails_clearly(self) -> None:
+        global_config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            """
+        )
+        command_config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-west"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", global_config_path, "capture-deploy", "--config", command_config_path])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("provide --config either before or after the command, not both", error.getvalue())
 
     def test_cli_values_override_config_defaults(self) -> None:
         config_path = self.write_config(


### PR DESCRIPTION
## Summary
- Adds explicit `--config PATH` support for TOML `schema_version = 1` execution defaults.
- Allows `--config` either before the subcommand or after the subcommand, while rejecting duplicate global and command-local config values clearly.
- Supports narrow config defaults for regions, TTL, source image, existing image id, and Linode type.
- Adds focused tests plus README/design/security/workflow docs and sanitized example configs.

## Scope confirmation
- M5 only: config loading, CLI integration, tests, docs, and examples.
- Follow-up fix is limited to config flag placement, focused tests, and docs wording.
- No runtime dependencies were added; config uses stdlib `tomllib`.
- No live Linode API behavior, scheduler integration, desired-state behavior, or multi-region execution was added.

## Safety guarantees
- CLI flags override config values.
- `--execute` cannot be set in config and must remain explicit on the CLI.
- Secret-like config keys fail clearly, including token/password/SSH/cloud-init/user-data style keys.
- `LINODE_TOKEN` still comes only from the environment or approved environment injection, never config.
- Multi-region config is accepted for dry-run only; execute mode still requires exactly one effective region and fails before token lookup.
- Behavior is unchanged except that `--config` can be placed before or after the subcommand.

## Validation
- `make check` passed locally after the follow-up fix.
- `make security-check` passed locally after the follow-up fix.
- Unit suite passed locally: 80 tests.

## Residual risks
- GitHub Actions may be briefly pending after the latest push.
- Config examples use placeholder image ids and are intended as public-safe templates, not account-specific ready-to-run files.