### PR TITLE
[codex] Harden release check validation gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,15 @@ release-check: check-gh-env
 		echo "Error: local main must match origin/main. Run 'git pull --ff-only origin main' and retry." >&2; \
 		exit 1; \
 	fi
+	@echo "Running validation: make check"
+	@if $(MAKE) check; then \
+		echo "Validation passed: make check completed successfully."; \
+	else \
+		status=$$?; \
+		echo "Validation failed: make check exited $$status." >&2; \
+		echo "Error: release blocked until canonical validation passes." >&2; \
+		exit $$status; \
+	fi
 	@if git rev-parse --verify --quiet "refs/tags/$(RELEASE_TAG)" >/dev/null; then \
 		echo "Error: local tag $(RELEASE_TAG) already exists." >&2; \
 		exit 1; \


### PR DESCRIPTION
## Summary

- Require `release-check` to run canonical validation with `make check` before release existence checks complete.
- Print explicit validation start, success, and blocked-failure messages.
- Preserve the existing clean tree, `main`, `origin/main`, tag, and GitHub release guards.

Closes #23.

## Validation

- `make check` passed.
- `make release-check VERSION=0.1.0` was run from a clean temporary checkout whose branch was `main`; the new validation gate passed, then the existing local tag guard blocked because `v0.1.0` already exists.
- `make release-check VERSION=0.1.0 PYTHON=false` was run from a clean temporary checkout whose branch was `main`; validation failed and release was blocked with the new failure message.

## Residual Risks

- Full `VERSION=0.1.0` release-check success cannot be demonstrated because `v0.1.0` already exists.
- No publishing commands or live Linode API calls were run.