### PR TITLE
[codex] Document GitHub tag installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ API, cleans up the temporary instances, and preserves the custom image.
 
 ## Installation
 
+Install the released `v0.1.0` tag directly from GitHub:
+
+```sh
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install git+https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0
+linode-image-lab --help
+```
+
 Run from source:
 
 ```sh


### PR DESCRIPTION
## Summary

- Document the supported `pip install git+https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0` path in the README.
- Keep editable source installation and no-install fallback instructions intact.
- Leave package metadata and runtime behavior unchanged because the released tag already installs and exposes the CLI successfully.

Closes #24.

## Validation

- `make check`
- Fresh venv smoke: `/private/tmp/linode-image-lab-issue24-smoke-2/bin/python -m pip install 'git+https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0'`
- Fresh venv CLI check: `/private/tmp/linode-image-lab-issue24-smoke-2/bin/linode-image-lab --help`

## Residual Risks

- The documented command is pinned to the currently released `v0.1.0` tag; future releases will need the README command updated if the supported release tag changes.
- No live Linode API calls were run.