### PR TITLE
feat: add executable cleanup for expired Linodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy \
 
 ## Authentication
 
-`LINODE_TOKEN` is required only when `--execute` is used. Dry-run commands do
-not read the token, call Linode, or mutate resources.
+`LINODE_TOKEN` is required when `--execute` is used. Dry-run capture, deploy,
+and capture-deploy commands do not read the token, call Linode, or mutate
+resources. Dry-run `cleanup` can use `LINODE_TOKEN` for read-only discovery
+when the token is available; it still never deletes resources without
+`--execute`.
 
 Use any shell method that exports the variable:
 
@@ -107,14 +110,14 @@ must still come from the environment or approved environment injection.
 ## Behavior Clarifications
 
 - All commands are dry-run by default.
-- `--execute` enables real Linode API mutations for `capture`, `deploy`, and
-  `capture-deploy`.
+- `--execute` enables real Linode API mutations for `capture`, `deploy`,
+  `capture-deploy`, and `cleanup`.
 - Config values only fill omitted command options; CLI flags override config.
 - Execute runs use temporary resources and clean them up automatically unless a
   preservation flag is used.
 - Custom images are preserved as deliverables.
-- `cleanup` is independently runnable and currently previews tag-scoped cleanup
-  selection.
+- `cleanup` is independently runnable, dry-run by default, and can delete
+  expired tagged temporary Linodes only with `--execute`.
 - Normal stdout is redacted for public-safe review.
 
 ## What This Does
@@ -172,6 +175,21 @@ linode-image-lab capture-deploy \
   --execute
 ```
 
+Preview or execute tag-scoped cleanup:
+
+```sh
+linode-image-lab cleanup
+LINODE_TOKEN='<your-linode-api-token>' linode-image-lab cleanup
+LINODE_TOKEN='<your-linode-api-token>' linode-image-lab cleanup --execute
+```
+
+`cleanup` without `--execute` never deletes resources. When `LINODE_TOKEN` is
+available, it performs read-only Linode discovery and reports expired eligible
+Linodes in `cleanup_candidates`; without a token, it emits the non-mutating
+manifest shape only. `cleanup --execute` requires `LINODE_TOKEN`, lists managed
+Linodes, and deletes only expired Linodes carrying the complete required tag
+set. Use `--run-id` to restrict selection to one run.
+
 ## Required Tags
 
 Modeled resources use rediscoverable tags:
@@ -193,6 +211,11 @@ Cleanup status values are literal: `deleted` means a temporary Linode was
 deleted, `preserved` means a resource was kept or skipped for safety,
 `completed` means combined cleanup finished, and `failed` means cleanup did not
 complete.
+
+Standalone `cleanup --execute` does not delete custom images, untagged
+resources, or resources with missing, malformed, unexpired, or mismatched
+managed tags. Preserved entries include a sanitized `reason`, such as
+`ttl_not_expired`, `ttl_parse_failed`, or `missing_required_tags`.
 
 ## Independence and Intent
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Safe, repeatable Linode image capture and deploy validation with automatic clean
 ## Quick Start
 
 Set `LINODE_TOKEN` first; execute mode reads it from the environment.
+Plain dry-run commands do not need it.
 
 ```sh
 python3 -m venv .venv
@@ -64,11 +65,9 @@ PYTHONPATH=src python3 -m linode_image_lab.cli capture-deploy \
 
 ## Authentication
 
-`LINODE_TOKEN` is required when `--execute` is used. Dry-run capture, deploy,
-and capture-deploy commands do not read the token, call Linode, or mutate
-resources. Dry-run `cleanup` can use `LINODE_TOKEN` for read-only discovery
-when the token is available; it still never deletes resources without
-`--execute`.
+`LINODE_TOKEN` is required when `--execute` is used and when `cleanup
+--discover` is used. Dry-run commands, including plain `cleanup`, do not read
+the token, call Linode, or mutate resources.
 
 Use any shell method that exports the variable:
 
@@ -103,9 +102,10 @@ Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
 on the command.
 
 Config is only for execution defaults. It cannot contain `LINODE_TOKEN`, token
-values, passwords, SSH keys, cloud-init data, `execute`, preservation flags, or
-run id fields. `--execute` must still be passed explicitly, and `LINODE_TOKEN`
-must still come from the environment or approved environment injection.
+values, passwords, SSH keys, cloud-init data, `execute`, `discover`,
+preservation flags, or run id fields. `--execute` or `cleanup --discover` must
+still be passed explicitly, and `LINODE_TOKEN` must still come from the
+environment or approved environment injection.
 
 ## Behavior Clarifications
 
@@ -179,16 +179,16 @@ Preview or execute tag-scoped cleanup:
 
 ```sh
 linode-image-lab cleanup
-LINODE_TOKEN='<your-linode-api-token>' linode-image-lab cleanup
+LINODE_TOKEN='<your-linode-api-token>' linode-image-lab cleanup --discover
 LINODE_TOKEN='<your-linode-api-token>' linode-image-lab cleanup --execute
 ```
 
-`cleanup` without `--execute` never deletes resources. When `LINODE_TOKEN` is
-available, it performs read-only Linode discovery and reports expired eligible
-Linodes in `cleanup_candidates`; without a token, it emits the non-mutating
-manifest shape only. `cleanup --execute` requires `LINODE_TOKEN`, lists managed
+Plain `cleanup` never reads `LINODE_TOKEN`, calls Linode, or deletes resources.
+`cleanup --discover` requires `LINODE_TOKEN`, performs read-only Linode
+discovery, and reports expired eligible Linodes in `cleanup_candidates` without
+deleting them. `cleanup --execute` requires `LINODE_TOKEN`, lists managed
 Linodes, and deletes only expired Linodes carrying the complete required tag
-set. Use `--run-id` to restrict selection to one run.
+set. Use `--run-id` to restrict discovery or deletion to one run.
 
 ## Required Tags
 

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -150,13 +150,21 @@ required tags are present:
 - `component=<capture|deploy>`
 - `ttl=<timestamp>`
 
-Execute-mode cleanup is narrower than general cleanup. Capture only attempts to
-delete the current run's temporary capture-source Linode, deploy only attempts
-to delete the current run's temporary deploy Linode, and capture-deploy only
-attempts to delete those two temporary Linodes for the current combined run. In
-all cases, cleanup proceeds only when the resource has all required tags
-matching the current run. If tags are missing or do not match, cleanup preserves
-the resource and records `reason=tag_mismatch`.
+Execute-mode cleanup inside capture, deploy, and capture-deploy is narrower
+than standalone cleanup. Capture only attempts to delete the current run's
+temporary capture-source Linode, deploy only attempts to delete the current
+run's temporary deploy Linode, and capture-deploy only attempts to delete those
+two temporary Linodes for the current combined run. In all cases, cleanup
+proceeds only when the resource has all required tags matching the current run.
+If tags are missing or do not match, cleanup preserves the resource and records
+`reason=tag_mismatch`.
+
+Standalone `cleanup` is also dry-run by default. With `LINODE_TOKEN`, the dry
+run lists managed Linodes and reports expired eligible resources without
+deleting them. `cleanup --execute` requires `LINODE_TOKEN` and deletes only
+expired temporary Linodes with the complete required tag set. It does not delete
+custom images, untagged resources, or resources with malformed or unexpired TTL
+values.
 
 Cleanup manifests use the same fields across commands: `status`, `deleted`,
 and `preserved`. `deleted` lists temporary Linodes removed after required tags

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -159,12 +159,13 @@ proceeds only when the resource has all required tags matching the current run.
 If tags are missing or do not match, cleanup preserves the resource and records
 `reason=tag_mismatch`.
 
-Standalone `cleanup` is also dry-run by default. With `LINODE_TOKEN`, the dry
-run lists managed Linodes and reports expired eligible resources without
-deleting them. `cleanup --execute` requires `LINODE_TOKEN` and deletes only
-expired temporary Linodes with the complete required tag set. It does not delete
-custom images, untagged resources, or resources with malformed or unexpired TTL
-values.
+Standalone `cleanup` is also dry-run by default. Plain `cleanup` emits a local
+manifest preview only; it does not read `LINODE_TOKEN` or call Linode. `cleanup
+--discover` requires `LINODE_TOKEN`, lists managed Linodes, and reports expired
+eligible resources without deleting them. `cleanup --execute` requires
+`LINODE_TOKEN` and deletes only expired temporary Linodes with the complete
+required tag set. It does not delete custom images, untagged resources, or
+resources with malformed or unexpired TTL values.
 
 Cleanup manifests use the same fields across commands: `status`, `deleted`,
 and `preserved`. `deleted` lists temporary Linodes removed after required tags

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -26,7 +26,7 @@ Before opening a PR:
 - run `make check`,
 - confirm fixtures are sanitized,
 - confirm dry-run commands remain non-mutating,
-- confirm real mutation remains limited to explicit `capture --execute` and
-  `deploy --execute`, and `capture-deploy --execute`,
+- confirm real mutation remains limited to explicit `capture --execute`,
+  `deploy --execute`, `capture-deploy --execute`, and `cleanup --execute`,
 - confirm cleanup only targets resources with complete matching tags,
 - confirm docs describe behavior without private context.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -26,6 +26,9 @@ Before opening a PR:
 - run `make check`,
 - confirm fixtures are sanitized,
 - confirm dry-run commands remain non-mutating,
+- confirm plain `cleanup` does not read `LINODE_TOKEN` or call Linode,
+- confirm read-only cleanup discovery remains limited to explicit
+  `cleanup --discover`,
 - confirm real mutation remains limited to explicit `capture --execute`,
   `deploy --execute`, `capture-deploy --execute`, and `cleanup --execute`,
 - confirm cleanup only targets resources with complete matching tags,

--- a/docs/design.md
+++ b/docs/design.md
@@ -157,12 +157,12 @@ for that resource because preservation was requested or tags did not match.
 finish. `failed` means cleanup did not complete. Preserved entries include a
 `reason`; the custom image uses `deliverable`.
 
-Standalone `cleanup` is dry-run by default. Without `LINODE_TOKEN`, it emits a
-non-mutating manifest preview without API discovery. With `LINODE_TOKEN`, dry
-run performs read-only managed Linode discovery and reports expired eligible
-Linodes in `cleanup_candidates` without deleting them. `cleanup --execute`
-requires `LINODE_TOKEN`, performs the same discovery, and deletes only expired
-Linodes carrying all required managed tags:
+Standalone `cleanup` is dry-run by default. Plain `cleanup` emits a
+non-mutating manifest preview and never reads `LINODE_TOKEN` or calls Linode.
+`cleanup --discover` requires `LINODE_TOKEN`, performs read-only managed Linode
+discovery, and reports expired eligible Linodes in `cleanup_candidates` without
+deleting them. `cleanup --execute` requires `LINODE_TOKEN`, performs the same
+discovery, and deletes only expired Linodes carrying all required managed tags:
 
 - `project=linode-image-lab`
 - `run_id=...`

--- a/docs/design.md
+++ b/docs/design.md
@@ -38,7 +38,8 @@ cleanup as a first-class outcome.
 - `manifest.py` owns manifest creation, tag generation, and sanitized
   serialization.
 - `regions.py` owns one-or-many region parsing.
-- `cleanup.py` owns tag-based cleanup candidate selection.
+- `cleanup.py` owns tag-based cleanup candidate selection and standalone
+  cleanup execution.
 - `redaction.py` owns recursive output sanitization.
 - `linode_api.py` owns the mockable Linode client boundary.
 
@@ -155,3 +156,21 @@ for that resource because preservation was requested or tags did not match.
 `completed` is reserved for combined cleanup after the phase cleanup blocks
 finish. `failed` means cleanup did not complete. Preserved entries include a
 `reason`; the custom image uses `deliverable`.
+
+Standalone `cleanup` is dry-run by default. Without `LINODE_TOKEN`, it emits a
+non-mutating manifest preview without API discovery. With `LINODE_TOKEN`, dry
+run performs read-only managed Linode discovery and reports expired eligible
+Linodes in `cleanup_candidates` without deleting them. `cleanup --execute`
+requires `LINODE_TOKEN`, performs the same discovery, and deletes only expired
+Linodes carrying all required managed tags:
+
+- `project=linode-image-lab`
+- `run_id=...`
+- `mode=...`
+- `component=...`
+- `ttl=...`
+
+Standalone cleanup never deletes custom images, untagged resources, or broader
+account resources. Malformed TTL values, future TTL values, missing required
+tags, invalid tag values, and optional `--run-id` filter mismatches preserve
+the Linode and report a sanitized reason.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,10 +8,8 @@ non-mutating; capture and deploy execution require explicit opt-in.
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
 - The CLI reads `LINODE_TOKEN` for `capture --execute`, `deploy --execute`,
-  `capture-deploy --execute`, and `cleanup --execute`.
-- `cleanup` without `--execute` may read `LINODE_TOKEN` only to perform
-  read-only discovery for a deletion preview. Other dry-run commands do not
-  read token values.
+  `capture-deploy --execute`, `cleanup --discover`, and `cleanup --execute`.
+- Plain `cleanup` does not read token values or call Linode.
 - Config files cannot provide `LINODE_TOKEN` or any token value. They only fill
   non-secret execution defaults after explicit `--config PATH`.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
@@ -26,17 +24,18 @@ when they appear in a table that is not used by the selected command.
 
 Supported config values are limited to region defaults, TTL, source image,
 existing custom image id, and Linode type. Config cannot set `--execute`,
-preservation flags, run ids, image labels, tokens, passwords, SSH keys, root
-passwords, cloud-init data, or user-data.
+`--discover`, preservation flags, run ids, image labels, tokens, passwords, SSH
+keys, root passwords, cloud-init data, or user-data.
 
-Config loading and validation happen before token lookup. Execute mode still
-requires `LINODE_TOKEN` from the environment or approved environment injection.
+Config loading and validation happen before token lookup. Execute mode and
+`cleanup --discover` still require `LINODE_TOKEN` from the environment or
+approved environment injection.
 
 ## Execute Permissions
 
-`capture --execute`, `deploy --execute`, `capture-deploy --execute`, and
-`cleanup --execute` need a personal access token or equivalent OAuth access
-that can:
+`capture --execute`, `deploy --execute`, `capture-deploy --execute`, `cleanup
+--discover`, and `cleanup --execute` need a personal access token or equivalent
+OAuth access that can:
 
 - read the current profile for preflight,
 - create, read, shut down, and delete temporary Linodes,
@@ -68,9 +67,9 @@ loss prevention system.
 ## Mutation Safety
 
 `plan` is dry-run only. `capture`, `deploy`, `capture-deploy`, and `cleanup`
-are dry-run unless `--execute` is provided. `cleanup` without `--execute` is
-non-mutating; when `LINODE_TOKEN` is available, it may call Linode only to list
-managed Linodes for a preview.
+are dry-run unless `--execute` is provided. Plain `cleanup` is a local manifest
+preview only; it does not read `LINODE_TOKEN` or call Linode. `cleanup
+--discover` is the explicit read-only provider discovery path.
 
 `capture --execute`, `deploy --execute`, and `capture-deploy --execute` fail
 before mutation if required options or `LINODE_TOKEN` are missing. They perform

--- a/docs/security.md
+++ b/docs/security.md
@@ -7,9 +7,11 @@ non-mutating; capture and deploy execution require explicit opt-in.
 
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
-- The CLI reads `LINODE_TOKEN` only for `capture --execute`,
-  `deploy --execute`, or `capture-deploy --execute`.
-- Dry-run commands do not read token values.
+- The CLI reads `LINODE_TOKEN` for `capture --execute`, `deploy --execute`,
+  `capture-deploy --execute`, and `cleanup --execute`.
+- `cleanup` without `--execute` may read `LINODE_TOKEN` only to perform
+  read-only discovery for a deletion preview. Other dry-run commands do not
+  read token values.
 - Config files cannot provide `LINODE_TOKEN` or any token value. They only fill
   non-secret execution defaults after explicit `--config PATH`.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
@@ -32,8 +34,9 @@ requires `LINODE_TOKEN` from the environment or approved environment injection.
 
 ## Execute Permissions
 
-`capture --execute`, `deploy --execute`, and `capture-deploy --execute` need a
-personal access token or equivalent OAuth access that can:
+`capture --execute`, `deploy --execute`, `capture-deploy --execute`, and
+`cleanup --execute` need a personal access token or equivalent OAuth access
+that can:
 
 - read the current profile for preflight,
 - create, read, shut down, and delete temporary Linodes,
@@ -43,9 +46,9 @@ personal access token or equivalent OAuth access that can:
 In Linode scope terms, this generally means `linodes:read_write` and
 `images:read_write`, plus account permissions or grants that allow Linode
 creation and tagging. Deploy execution from an existing image does not create a
-custom image, but the same image read permissions are expected. If tags cannot
-be applied or later verified, execution fails safely because cleanup depends on
-rediscoverable tags.
+custom image, and standalone cleanup does not create or delete custom images.
+If tags cannot be applied or later verified, execution fails safely because
+cleanup depends on rediscoverable tags.
 
 ## Public-Safety Scan
 
@@ -64,9 +67,10 @@ loss prevention system.
 
 ## Mutation Safety
 
-`plan` is dry-run only. `capture`, `deploy`, and `capture-deploy` are dry-run
-unless `--execute` is provided. `cleanup` currently selects candidates from
-provided data structures and does not call Linode.
+`plan` is dry-run only. `capture`, `deploy`, `capture-deploy`, and `cleanup`
+are dry-run unless `--execute` is provided. `cleanup` without `--execute` is
+non-mutating; when `LINODE_TOKEN` is available, it may call Linode only to list
+managed Linodes for a preview.
 
 `capture --execute`, `deploy --execute`, and `capture-deploy --execute` fail
 before mutation if required options or `LINODE_TOKEN` are missing. They perform
@@ -79,6 +83,13 @@ deletion attempts.
 component-specific tag: capture resources use `component=capture`, and deploy
 resources use `component=deploy`. The custom image is preserved by default.
 Temporary Linodes are deleted only when all required tags match the current run.
+
+Standalone `cleanup --execute` deletes only expired temporary Linodes with the
+complete managed tag set: `project`, `run_id`, `mode`, `component`, and `ttl`.
+It preserves custom images, untagged resources, resources with missing or
+mismatched tags, resources with malformed or unexpired TTL values, and resources
+outside an optional `--run-id` filter. Preserved entries use sanitized reason
+strings and normal stdout redacts provider identifiers.
 
 Validation is limited to provider/API responses: resource state, requested
 region, required tags, disk presence for capture, and image availability for

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
-from .linode_api import TOKEN_ENV_NAME, LinodeClient, LinodeClientProtocol
+from .linode_api import LinodeClient, LinodeClientProtocol
 from .manifest import PROJECT, REQUIRED_TAG_KEYS, VALID_COMPONENTS, VALID_MODES, tags_to_dict
 
 
@@ -23,6 +22,7 @@ class CleanupError(ValueError):
 class CleanupOptions:
     run_id: str | None = None
     ttl: str | None = None
+    discover: bool = False
     execute: bool = False
 
 
@@ -72,27 +72,27 @@ def cleanup_plan(
     *,
     run_id: str | None = None,
     ttl: str | None = None,
+    discover: bool = False,
     execute: bool = False,
     client: LinodeClientProtocol | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    options = CleanupOptions(run_id=run_id, ttl=ttl, execute=execute)
+    options = CleanupOptions(run_id=run_id, ttl=ttl, discover=discover, execute=execute)
     manifest = base_cleanup_manifest(options)
-    if not execute and client is None:
-        if TOKEN_ENV_NAME not in os.environ:
-            manifest["message"] = "cleanup is non-mutating; set LINODE_TOKEN to preview discovered Linodes"
-            manifest["discovery"] = {"status": "not_requested", "reason": "token_not_provided"}
-            return manifest
+    if not discover and not execute:
+        manifest["message"] = "cleanup is non-mutating; use --discover to list Linodes or --execute to delete expired Linodes"
+        manifest["discovery"] = {"status": "not_requested"}
+        return manifest
 
-    run_client = client or LinodeClient.from_env(command="cleanup")
+    option = "--execute" if execute else "--discover"
+    run_client = client or LinodeClient.from_env(command="cleanup", option=option)
     manifest["steps"] = []
     manifest["cleanup"] = {"status": "running", "deleted": [], "preserved": []}
 
     try:
-        if execute:
-            append_step(manifest, "preflight_api_access", mutates=False, status="running")
-            run_client.preflight()
-            finish_step(manifest, "preflight_api_access")
+        append_step(manifest, "preflight_api_access", mutates=False, status="running")
+        run_client.preflight()
+        finish_step(manifest, "preflight_api_access")
 
         append_step(manifest, "discover_managed_linodes", mutates=False, status="running")
         resources = run_client.list_managed_linodes()
@@ -105,7 +105,7 @@ def cleanup_plan(
             item["resource"] for item in assessments if item["action"] == "preserve"
         ]
 
-        if not execute:
+        if discover:
             manifest["cleanup"]["status"] = "previewed"
             manifest["status"] = "planned"
             manifest["discovery"] = {"status": "completed"}
@@ -135,7 +135,7 @@ def cleanup_plan(
         manifest["status"] = "failed"
         manifest["cleanup"]["status"] = "failed"
         manifest["errors"] = [safe_error_message(exc)]
-        message = "cleanup --execute failed" if execute else "cleanup dry-run failed"
+        message = "cleanup --execute failed" if execute else "cleanup --discover failed"
         raise CleanupError(message, manifest) from exc
 
 
@@ -149,13 +149,21 @@ def base_cleanup_manifest(options: CleanupOptions) -> dict[str, Any]:
         "regions": [],
         "ttl": options.ttl,
         "dry_run": not options.execute,
-        "execution_mode": "execute" if options.execute else "dry-run",
-        "status": "running" if options.execute else "planned",
+        "execution_mode": cleanup_execution_mode(options),
+        "status": "running" if options.execute or options.discover else "planned",
         "filters": {"run_id": options.run_id},
         "resources": [],
         "cleanup_candidates": [],
         "cleanup": {"status": "not_started", "deleted": [], "preserved": []},
     }
+
+
+def cleanup_execution_mode(options: CleanupOptions) -> str:
+    if options.execute:
+        return "execute"
+    if options.discover:
+        return "discover"
+    return "dry-run"
 
 
 def assess_cleanup(

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -1,11 +1,29 @@
-"""Cleanup selection logic for tagged resources."""
+"""Cleanup selection and execution logic for tagged temporary Linodes."""
 
 from __future__ import annotations
 
+import os
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from .linode_api import TOKEN_ENV_NAME, LinodeClient, LinodeClientProtocol
 from .manifest import PROJECT, REQUIRED_TAG_KEYS, VALID_COMPONENTS, VALID_MODES, tags_to_dict
+
+
+class CleanupError(ValueError):
+    """Raised when cleanup cannot safely complete."""
+
+    def __init__(self, message: str, manifest: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.manifest = manifest
+
+
+@dataclass(frozen=True)
+class CleanupOptions:
+    run_id: str | None = None
+    ttl: str | None = None
+    execute: bool = False
 
 
 def parse_ttl(value: str) -> datetime | None:
@@ -48,3 +66,174 @@ def select_cleanup_candidates(
     now: datetime | None = None,
 ) -> list[dict[str, Any]]:
     return [resource for resource in resources if is_cleanup_candidate(resource, now=now)]
+
+
+def cleanup_plan(
+    *,
+    run_id: str | None = None,
+    ttl: str | None = None,
+    execute: bool = False,
+    client: LinodeClientProtocol | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    options = CleanupOptions(run_id=run_id, ttl=ttl, execute=execute)
+    manifest = base_cleanup_manifest(options)
+    if not execute and client is None:
+        if TOKEN_ENV_NAME not in os.environ:
+            manifest["message"] = "cleanup is non-mutating; set LINODE_TOKEN to preview discovered Linodes"
+            manifest["discovery"] = {"status": "not_requested", "reason": "token_not_provided"}
+            return manifest
+
+    run_client = client or LinodeClient.from_env(command="cleanup")
+    manifest["steps"] = []
+    manifest["cleanup"] = {"status": "running", "deleted": [], "preserved": []}
+
+    try:
+        if execute:
+            append_step(manifest, "preflight_api_access", mutates=False, status="running")
+            run_client.preflight()
+            finish_step(manifest, "preflight_api_access")
+
+        append_step(manifest, "discover_managed_linodes", mutates=False, status="running")
+        resources = run_client.list_managed_linodes()
+        manifest["resources"] = [resource_summary(resource) for resource in resources]
+        finish_step(manifest, "discover_managed_linodes")
+
+        assessments = assess_cleanup(resources, run_id=run_id, now=now)
+        manifest["cleanup_candidates"] = [item["resource"] for item in assessments if item["action"] == "delete"]
+        manifest["cleanup"]["preserved"] = [
+            item["resource"] for item in assessments if item["action"] == "preserve"
+        ]
+
+        if not execute:
+            manifest["cleanup"]["status"] = "previewed"
+            manifest["status"] = "planned"
+            manifest["discovery"] = {"status": "completed"}
+            return manifest
+
+        append_step(manifest, "delete_expired_linodes", mutates=bool(manifest["cleanup_candidates"]), status="running")
+        deleted: list[dict[str, Any]] = []
+        for item in assessments:
+            if item["action"] != "delete":
+                continue
+            linode_id = item["linode_id"]
+            if not isinstance(linode_id, int):
+                item["resource"]["reason"] = "missing_provider_id"
+                manifest["cleanup"]["preserved"].append(item["resource"])
+                continue
+            run_client.delete_instance(linode_id)
+            deleted.append(item["resource"])
+        manifest["cleanup"]["deleted"] = deleted
+        manifest["cleanup_candidates"] = []
+        manifest["cleanup"]["status"] = "completed"
+        manifest["status"] = "succeeded"
+        manifest["discovery"] = {"status": "completed"}
+        finish_step(manifest, "delete_expired_linodes")
+        return manifest
+    except Exception as exc:
+        mark_running_step_failed(manifest)
+        manifest["status"] = "failed"
+        manifest["cleanup"]["status"] = "failed"
+        manifest["errors"] = [safe_error_message(exc)]
+        message = "cleanup --execute failed" if execute else "cleanup dry-run failed"
+        raise CleanupError(message, manifest) from exc
+
+
+def base_cleanup_manifest(options: CleanupOptions) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "project": PROJECT,
+        "command": "cleanup",
+        "mode": "cleanup",
+        "run_id": options.run_id,
+        "regions": [],
+        "ttl": options.ttl,
+        "dry_run": not options.execute,
+        "execution_mode": "execute" if options.execute else "dry-run",
+        "status": "running" if options.execute else "planned",
+        "filters": {"run_id": options.run_id},
+        "resources": [],
+        "cleanup_candidates": [],
+        "cleanup": {"status": "not_started", "deleted": [], "preserved": []},
+    }
+
+
+def assess_cleanup(
+    resources: list[dict[str, Any]],
+    *,
+    run_id: str | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    comparison_time = (now or datetime.now(UTC)).astimezone(UTC)
+    return [assess_resource(resource, run_id=run_id, now=comparison_time) for resource in resources]
+
+
+def assess_resource(resource: dict[str, Any], *, run_id: str | None, now: datetime) -> dict[str, Any]:
+    summary = resource_summary(resource)
+    tags = resource_tags(resource)
+
+    if any(key not in tags for key in REQUIRED_TAG_KEYS):
+        summary["reason"] = "missing_required_tags"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+    if tags["project"] != PROJECT:
+        summary["reason"] = "tag_mismatch"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+    if run_id is not None and tags["run_id"] != run_id:
+        summary["reason"] = "run_id_filter_mismatch"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+    if tags["mode"] not in VALID_MODES or tags["component"] not in VALID_COMPONENTS:
+        summary["reason"] = "tag_mismatch"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+
+    ttl = parse_ttl(tags["ttl"])
+    if ttl is None:
+        summary["reason"] = "ttl_parse_failed"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+    if ttl > now:
+        summary["reason"] = "ttl_not_expired"
+        return {"action": "preserve", "resource": summary, "linode_id": resource.get("linode_id")}
+
+    summary["reason"] = "expired_ttl"
+    return {"action": "delete", "resource": summary, "linode_id": resource.get("linode_id")}
+
+
+def resource_summary(resource: dict[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "resource_type": "linode",
+        "linode_id": resource.get("linode_id", resource.get("id")),
+        "tags": list(resource.get("tags", [])),
+    }
+    for key in ("label", "region", "status"):
+        if key in resource:
+            summary[key] = resource[key]
+    return summary
+
+
+def append_step(
+    manifest: dict[str, Any],
+    name: str,
+    *,
+    mutates: bool,
+    status: str,
+) -> None:
+    manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
+
+
+def finish_step(manifest: dict[str, Any], name: str) -> None:
+    for step in reversed(manifest["steps"]):
+        if step["name"] == name:
+            step["status"] = "succeeded"
+            return
+
+
+def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+    for step in reversed(manifest.get("steps", [])):
+        if step.get("status") == "running":
+            step["status"] = "failed"
+            return
+
+
+def safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, CleanupError):
+        return str(exc)
+    return exc.__class__.__name__

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -90,9 +90,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep the temporary deploy validation Linode after execution.",
     )
 
-    cleanup = subparsers.add_parser("cleanup", help="Plan or execute tag-scoped cleanup.")
+    cleanup = subparsers.add_parser("cleanup", help="Plan, discover, or execute tag-scoped cleanup.")
     add_config_arg(cleanup, dest="command_config")
-    cleanup.add_argument("--execute", action="store_true", help="Opt into Linode API deletion of expired resources.")
+    cleanup_mode = cleanup.add_mutually_exclusive_group()
+    cleanup_mode.add_argument("--discover", action="store_true", help="Opt into read-only Linode discovery.")
+    cleanup_mode.add_argument("--execute", action="store_true", help="Opt into Linode API deletion of expired resources.")
     cleanup.add_argument("--run-id", help="Optional run id filter for cleanup selection.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
@@ -191,6 +193,7 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
         return cleanup_plan(
             run_id=args.run_id,
             ttl=args.ttl,
+            discover=args.discover,
             execute=args.execute,
         )
 

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from typing import Any
 
-from .cleanup import select_cleanup_candidates
+from .cleanup import CleanupError, cleanup_plan
 from .capture import CaptureError, capture_plan
 from .capture_deploy import CaptureDeployError, capture_deploy_plan
 from .config import ConfigError, command_defaults, load_config
@@ -90,9 +90,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep the temporary deploy validation Linode after execution.",
     )
 
-    cleanup = subparsers.add_parser("cleanup", help="Preview tag-scoped cleanup selection.")
+    cleanup = subparsers.add_parser("cleanup", help="Plan or execute tag-scoped cleanup.")
     add_config_arg(cleanup, dest="command_config")
-    cleanup.add_argument("--run-id", help="Optional run id to include in the cleanup preview.")
+    cleanup.add_argument("--execute", action="store_true", help="Opt into Linode API deletion of expired resources.")
+    cleanup.add_argument("--run-id", help="Optional run id filter for cleanup selection.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
     return parser
@@ -187,18 +188,11 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
         )
 
     if args.command == "cleanup":
-        manifest = create_manifest(
-            command="cleanup",
-            mode="capture-deploy",
-            regions=[],
+        return cleanup_plan(
             run_id=args.run_id,
             ttl=args.ttl,
-            dry_run=True,
-            status="placeholder",
+            execute=args.execute,
         )
-        manifest["message"] = "cleanup is independently runnable and non-mutating"
-        manifest["cleanup_candidates"] = select_cleanup_candidates([])
-        return manifest
 
     raise ValueError(f"unsupported command: {args.command}")
 
@@ -225,6 +219,12 @@ def main(argv: list[str] | None = None) -> int:
         if exc.manifest is not None:
             sys.stdout.write(serialize_manifest(exc.manifest))
             sys.stderr.write("capture-deploy --execute failed\n")
+            return 1
+        parser.error(str(exc))
+    except CleanupError as exc:
+        if exc.manifest is not None:
+            sys.stdout.write(serialize_manifest(exc.manifest))
+            sys.stderr.write(f"{exc}\n")
             return 1
         parser.error(str(exc))
     except (ConfigError, ValueError) as exc:

--- a/src/linode_image_lab/config.py
+++ b/src/linode_image_lab/config.py
@@ -30,6 +30,7 @@ TABLE_FIELDS = {
 }
 COMMAND_TABLES = {"capture", "deploy", "capture-deploy", "cleanup"}
 PROHIBITED_KEYS = {
+    "discover",
     "execute",
     "image-label",
     "image_label",

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -8,8 +8,10 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 from urllib.error import HTTPError
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
+
+from .manifest import PROJECT, tags_to_dict
 
 TOKEN_ENV_NAME = "LINODE_TOKEN"
 DEFAULT_API_BASE_URL = "https://api.linode.com/v4"
@@ -56,6 +58,8 @@ class LinodeClientProtocol(Protocol):
     ) -> dict[str, Any]: ...
 
     def wait_image_available(self, image_id: str) -> dict[str, Any]: ...
+
+    def list_managed_linodes(self) -> list[dict[str, Any]]: ...
 
     def delete_instance(self, linode_id: int) -> dict[str, Any]: ...
 
@@ -146,6 +150,26 @@ class LinodeClient:
             return self._image_resource(response)
 
         return self._wait_until(current, lambda resource: resource.get("status") == "available")
+
+    def list_managed_linodes(self) -> list[dict[str, Any]]:
+        resources: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            query = urlencode({"page": page, "page_size": 100})
+            response = self._request("GET", f"/linode/instances?{query}")
+            data = response.get("data", []) if isinstance(response, dict) else []
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                resource = self._instance_resource(item)
+                tags = tags_to_dict(resource.get("tags", []))
+                if tags.get("project") == PROJECT:
+                    resources.append(resource)
+
+            pages = response.get("pages", page) if isinstance(response, dict) else page
+            if not isinstance(pages, int) or page >= pages:
+                return resources
+            page += 1
 
     def delete_instance(self, linode_id: int) -> dict[str, Any]:
         self._request("DELETE", f"/linode/instances/{linode_id}")

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -75,11 +75,17 @@ class LinodeClient:
     max_wait_seconds: float = 900
 
     @classmethod
-    def from_env(cls, env: dict[str, str] | None = None, *, command: str = "capture") -> "LinodeClient":
+    def from_env(
+        cls,
+        env: dict[str, str] | None = None,
+        *,
+        command: str = "capture",
+        option: str = "--execute",
+    ) -> "LinodeClient":
         values = env if env is not None else os.environ
         token = values.get(TOKEN_ENV_NAME)
         if not token:
-            raise LinodeTokenError(f"{TOKEN_ENV_NAME} is required for {command} --execute")
+            raise LinodeTokenError(f"{TOKEN_ENV_NAME} is required for {command} {option}")
         return cls(token=token)
 
     def preflight(self) -> None:

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -5,7 +5,44 @@ import unittest
 from datetime import UTC, datetime
 from pathlib import Path
 
-from linode_image_lab.cleanup import select_cleanup_candidates
+from linode_image_lab.cleanup import cleanup_plan, select_cleanup_candidates
+from linode_image_lab.manifest import serialize_manifest
+
+
+NOW = datetime(2026, 5, 1, tzinfo=UTC)
+
+
+class FakeCleanupClient:
+    def __init__(self, resources: list[dict[str, object]]) -> None:
+        self.resources = resources
+        self.preflight_count = 0
+        self.deleted: list[int] = []
+
+    def preflight(self) -> None:
+        self.preflight_count += 1
+
+    def list_managed_linodes(self) -> list[dict[str, object]]:
+        return list(self.resources)
+
+    def delete_instance(self, linode_id: int) -> dict[str, object]:
+        self.deleted.append(linode_id)
+        return {"linode_id": linode_id, "deleted": True}
+
+
+def linode_resource(*, linode_id: int = 123, ttl: str = "2026-01-01T00:00:00Z") -> dict[str, object]:
+    return {
+        "linode_id": linode_id,
+        "label": "lil-run-test",
+        "region": "us-east",
+        "status": "running",
+        "tags": [
+            "project=linode-image-lab",
+            "run_id=run-test",
+            "mode=capture-deploy",
+            "component=capture",
+            f"ttl={ttl}",
+        ],
+    }
 
 
 class CleanupSelectionTests(unittest.TestCase):
@@ -16,10 +53,89 @@ class CleanupSelectionTests(unittest.TestCase):
 
         selected = select_cleanup_candidates(
             resources,
-            now=datetime(2026, 5, 1, tzinfo=UTC),
+            now=NOW,
         )
 
         self.assertEqual([resource["id"] for resource in selected], ["resource-expired"])
+
+    def test_dry_run_discovers_but_does_not_delete(self) -> None:
+        client = FakeCleanupClient([linode_resource()])
+
+        manifest = cleanup_plan(client=client, now=NOW)
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "dry-run")
+        self.assertEqual(manifest["cleanup"]["status"], "previewed")
+        self.assertEqual(len(manifest["cleanup_candidates"]), 1)
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(client.preflight_count, 0)
+
+    def test_execute_deletes_expired_tagged_linode(self) -> None:
+        client = FakeCleanupClient([linode_resource(linode_id=456)])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertFalse(manifest["dry_run"])
+        self.assertEqual(manifest["status"], "succeeded")
+        self.assertEqual(client.preflight_count, 1)
+        self.assertEqual(client.deleted, [456])
+        self.assertEqual(manifest["cleanup"]["deleted"][0]["reason"], "expired_ttl")
+
+    def test_unexpired_linode_is_preserved(self) -> None:
+        client = FakeCleanupClient([linode_resource(ttl="2030-01-01T00:00:00Z")])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "ttl_not_expired")
+
+    def test_malformed_ttl_is_preserved(self) -> None:
+        client = FakeCleanupClient([linode_resource(ttl="not-a-timestamp")])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "ttl_parse_failed")
+
+    def test_missing_required_tags_are_preserved(self) -> None:
+        client = FakeCleanupClient(
+            [
+                {
+                    "linode_id": 789,
+                    "tags": ["project=linode-image-lab", "run_id=run-test"],
+                }
+            ]
+        )
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "missing_required_tags")
+
+    def test_mismatched_managed_tags_are_preserved(self) -> None:
+        resource = linode_resource()
+        resource["tags"] = [
+            "project=linode-image-lab",
+            "run_id=run-test",
+            "mode=unexpected",
+            "component=capture",
+            "ttl=2026-01-01T00:00:00Z",
+        ]
+        client = FakeCleanupClient([resource])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+
+    def test_provider_ids_are_redacted_in_serialized_manifest(self) -> None:
+        client = FakeCleanupClient([linode_resource(linode_id=987)])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+        exported = json.loads(serialize_manifest(manifest))
+
+        self.assertEqual(exported["cleanup"]["deleted"][0]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["resources"][0]["linode_id"], "[REDACTED]")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -16,12 +16,14 @@ class FakeCleanupClient:
     def __init__(self, resources: list[dict[str, object]]) -> None:
         self.resources = resources
         self.preflight_count = 0
+        self.list_count = 0
         self.deleted: list[int] = []
 
     def preflight(self) -> None:
         self.preflight_count += 1
 
     def list_managed_linodes(self) -> list[dict[str, object]]:
+        self.list_count += 1
         return list(self.resources)
 
     def delete_instance(self, linode_id: int) -> dict[str, object]:
@@ -58,17 +60,31 @@ class CleanupSelectionTests(unittest.TestCase):
 
         self.assertEqual([resource["id"] for resource in selected], ["resource-expired"])
 
-    def test_dry_run_discovers_but_does_not_delete(self) -> None:
+    def test_plain_cleanup_does_not_discover_or_delete(self) -> None:
         client = FakeCleanupClient([linode_resource()])
 
         manifest = cleanup_plan(client=client, now=NOW)
 
         self.assertTrue(manifest["dry_run"])
         self.assertEqual(manifest["execution_mode"], "dry-run")
+        self.assertEqual(manifest["cleanup"]["status"], "not_started")
+        self.assertEqual(manifest["cleanup_candidates"], [])
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(client.preflight_count, 0)
+        self.assertEqual(client.list_count, 0)
+
+    def test_discover_lists_but_does_not_delete(self) -> None:
+        client = FakeCleanupClient([linode_resource()])
+
+        manifest = cleanup_plan(discover=True, client=client, now=NOW)
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "discover")
         self.assertEqual(manifest["cleanup"]["status"], "previewed")
         self.assertEqual(len(manifest["cleanup_candidates"]), 1)
         self.assertEqual(client.deleted, [])
-        self.assertEqual(client.preflight_count, 0)
+        self.assertEqual(client.preflight_count, 1)
+        self.assertEqual(client.list_count, 1)
 
     def test_execute_deletes_expired_tagged_linode(self) -> None:
         client = FakeCleanupClient([linode_resource(linode_id=456)])

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -273,6 +273,23 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("key is not supported: execute", error.getvalue())
 
+    def test_discover_in_config_is_rejected(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [cleanup]
+            discover = "true"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", config_path, "cleanup"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("key is not supported: discover", error.getvalue())
+
     def test_config_never_satisfies_linode_token(self) -> None:
         config_path = self.write_config(
             """
@@ -301,6 +318,29 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("LINODE_TOKEN is required for cleanup --execute", error.getvalue())
+
+    def test_cleanup_discover_requires_linode_token(self) -> None:
+        error = StringIO()
+        with patch.dict(os.environ, {}, clear=True):
+            with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+                main(["cleanup", "--discover"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("LINODE_TOKEN is required for cleanup --discover", error.getvalue())
+
+    def test_cleanup_plain_does_not_require_linode_token(self) -> None:
+        output = StringIO()
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("linode_image_lab.cleanup.LinodeClient.from_env", side_effect=AssertionError("token lookup")),
+            redirect_stdout(output),
+        ):
+            code = main(["cleanup"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["execution_mode"], "dry-run")
+        self.assertEqual(payload["discovery"]["status"], "not_requested")
 
     def test_multi_region_config_is_accepted_for_dry_run(self) -> None:
         config_path = self.write_config(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -293,6 +293,15 @@ class CliTests(unittest.TestCase):
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("LINODE_TOKEN is required for deploy --execute", error.getvalue())
 
+    def test_cleanup_execute_requires_linode_token(self) -> None:
+        error = StringIO()
+        with patch.dict(os.environ, {}, clear=True):
+            with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+                main(["cleanup", "--execute"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("LINODE_TOKEN is required for cleanup --execute", error.getvalue())
+
     def test_multi_region_config_is_accepted_for_dry_run(self) -> None:
         config_path = self.write_config(
             """

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -204,6 +204,66 @@ class LinodeClientTests(unittest.TestCase):
         self.assertIsNone(getattr(requests[0], "data"))
         self.assertEqual(resource, {"linode_id": 123, "deleted": True})
 
+    def test_list_managed_linodes_maps_project_tagged_instances(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        responses = [
+            FakeHTTPResponse(
+                {
+                    "page": 1,
+                    "pages": 2,
+                    "data": [
+                        {
+                            "id": 123,
+                            "label": "lil-run-source",
+                            "region": "us-east",
+                            "status": "running",
+                            "tags": ["project=linode-image-lab"],
+                        },
+                        {
+                            "id": 999,
+                            "label": "unmanaged",
+                            "region": "us-east",
+                            "status": "running",
+                            "tags": ["project=other"],
+                        },
+                    ],
+                }
+            ),
+            FakeHTTPResponse(
+                {
+                    "page": 2,
+                    "pages": 2,
+                    "data": [
+                        {
+                            "id": 456,
+                            "label": "lil-run-deploy",
+                            "region": "us-west",
+                            "status": "offline",
+                            "tags": ["project=linode-image-lab"],
+                        }
+                    ],
+                }
+            ),
+        ]
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return responses.pop(0)
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resources = client.list_managed_linodes()
+
+        self.assertEqual([request.get_method() for request in requests], ["GET", "GET"])
+        self.assertEqual(
+            [request.full_url for request in requests],
+            [
+                f"{API_BASE_URL}/linode/instances?page=1&page_size=100",
+                f"{API_BASE_URL}/linode/instances?page=2&page_size=100",
+            ],
+        )
+        self.assertEqual([resource["linode_id"] for resource in resources], [123, 456])
+
     def test_wait_instance_ready_polls_until_running(self) -> None:
         client = LinodeClient(
             token=TOKEN_VALUE,

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -47,6 +47,10 @@ class LinodeClientTests(unittest.TestCase):
         with self.assertRaisesRegex(LinodeTokenError, "LINODE_TOKEN"):
             LinodeClient.from_env({})
 
+    def test_from_env_missing_token_names_requested_option(self) -> None:
+        with self.assertRaisesRegex(LinodeTokenError, "cleanup --discover"):
+            LinodeClient.from_env({}, command="cleanup", option="--discover")
+
     def test_preflight_issues_profile_and_grants_requests(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, timeout_seconds=7)
         responses = [FakeHTTPResponse({}), FakeHTTPResponse(b"")]


### PR DESCRIPTION
## Summary

- Add standalone `cleanup --execute` with token preflight, managed Linode discovery, TTL evaluation, and tag-scoped deletion.
- Keep default cleanup dry-run/non-mutating, including read-only preview output when discovery is available.
- Preserve and report Linodes with missing tags, mismatched tags, malformed TTLs, unexpired TTLs, or run-id filter mismatches; custom images remain out of scope.
- Add fake/no-network tests for dry-run, token requirements, deletion, preservation paths, redaction, and paginated Linode listing.
- Update README and docs for cleanup behavior and safety boundaries.

Closes #16

## Validation

- `make check`
- `make security-check`

## Residual Risks

- No live Linode API calls were run; API behavior is covered by mocked request tests only.
- Dry-run discovery depends on `LINODE_TOKEN` being available for read-only API listing; without it, cleanup emits the non-mutating manifest shape only.