### PR TITLE
[codex] Require Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Safe, repeatable Linode image capture and deploy validation with automatic clean
 
 ## Quick Start
 
+Requires Python 3.12 or newer.
+
 Set `LINODE_TOKEN` first; execute mode reads it from the environment.
 Plain dry-run commands do not need it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "linode-image-lab"
 version = "0.1.0"
 description = "Public-safe Linode custom image capture and deploy workflow lab."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Update project metadata to require Python 3.12 or newer.
- Document the Python 3.12+ support floor in the README quick start.
- Confirmed no runtime version gates or older-Python compatibility paths are present.

## Validation

- `make check`
- `make security-check`