### PR TITLE
Add provider preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Safe, repeatable Linode image capture and deploy validation with automatic clean
 - Plans capture, deploy, and capture-deploy runs before any API mutation.
 - Captures custom images from temporary Linode instances.
 - Deploys temporary validation instances from custom images.
-- Validates requested region, tags, resources, and running status at the API level.
+- Validates requested region, Linode type, image inputs, tags, resources, and
+  running status at the API level.
 - Cleans up temporary resources while preserving custom images as deliverables.
 - Emits redacted, public-safe manifests for review and automation.
 
@@ -148,6 +149,8 @@ environment or approved environment injection.
 - Config values only fill omitted command options; CLI flags override config.
 - Execute runs use temporary resources and clean them up automatically unless a
   preservation flag is used.
+- Execute runs verify the requested region, Linode type, and source or deploy
+  image with read-only Linode API calls before resource creation.
 - Custom images are preserved as deliverables.
 - `cleanup` is independently runnable, dry-run by default, and can delete
   expired tagged temporary Linodes only with `--execute`.
@@ -157,7 +160,8 @@ environment or approved environment injection.
 
 - Captures custom images from temporary Linode instances.
 - Deploys temporary validation instances.
-- Validates region, tags, resources, and running status at the API level.
+- Validates region, Linode type, image inputs, tags, resources, and running
+  status at the API level.
 - Cleans up temporary resources.
 
 ## What This Does Not Do

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -21,13 +21,15 @@ resources and may incur account charges until cleanup completes. It requires:
 Execution steps:
 
 1. preflight token access without mutating resources,
-2. create a temporary capture-source Linode from the source image,
-3. wait until the source is ready,
-4. validate provider/API-level region, required tags, and disk presence,
-5. power off the source,
-6. create a custom image from the selected disk,
-7. wait until the provider reports the image is available,
-8. delete the temporary source unless `--preserve-source` is set.
+2. verify the requested region, Linode type, and source image with read-only
+   API calls,
+3. create a temporary capture-source Linode from the source image,
+4. wait until the source is ready,
+5. validate provider/API-level region, required tags, and disk presence,
+6. power off the source,
+7. create a custom image from the selected disk,
+8. wait until the provider reports the image is available,
+9. delete the temporary source unless `--preserve-source` is set.
 
 The custom image is preserved by default because it is the capture deliverable.
 Capture validation stops at provider/API data; it does not perform SSH,
@@ -50,10 +52,12 @@ account charges until cleanup completes. It requires:
 Execution steps:
 
 1. preflight token access without mutating resources,
-2. create a temporary deploy Linode from the custom image id,
-3. wait until the provider reports the instance is running,
-4. validate provider/API-level running status, requested region, and required tags,
-5. delete the temporary instance unless `--preserve-instance` is set.
+2. verify the requested region, Linode type, and deploy image with read-only API
+   calls,
+3. create a temporary deploy Linode from the custom image id,
+4. wait until the provider reports the instance is running,
+5. validate provider/API-level running status, requested region, and required tags,
+6. delete the temporary instance unless `--preserve-instance` is set.
 
 The deploy instance is deleted by default because deploy execution is a quick
 validation path, not a long-lived server creation flow.
@@ -110,8 +114,10 @@ redacts provider identifiers, so the image id is not exposed in serialized
 manifests.
 
 Capture-deploy intentionally runs the non-mutating API preflight inside both
-the capture and deploy phases. This keeps each phase independently safe and
-reusable, so combined manifests may show two `preflight_api_access` steps.
+the capture and deploy phases, including read-only provider checks for region,
+type, and image availability. This keeps each phase independently safe and
+reusable, so combined manifests may show two `preflight_api_access` and
+`preflight_provider_inputs` steps.
 
 Live smoke command shape:
 
@@ -183,10 +189,10 @@ top-level fields and also nests `capture` and `deploy` sections. Top-level
 `capture.resources`, `deploy.resources`, `capture.validation`, and
 `deploy.validation` are phase-specific slices of that same lifecycle.
 
-`validation` means provider/API-level checks only: resource state, requested
-region, required tags, disk presence for capture, and image availability for
-capture. It does not include SSH, app health, service readiness, or cloud-init
-completion checks.
+`validation` means provider/API-level checks only: input availability, resource
+state, requested region, required tags, disk presence for capture, and image
+availability for capture. It does not include SSH, app health, service
+readiness, or cloud-init completion checks.
 
 Validation checks are structured as stable objects with `name`, `status`, and a
 symbolic `target`. Failed checks include a sanitized `failure_reason`; provider

--- a/docs/design.md
+++ b/docs/design.md
@@ -98,13 +98,15 @@ a Linode type, and `LINODE_TOKEN`.
 The execute flow is intentionally linear:
 
 1. preflight the token with non-mutating API calls,
-2. create a tagged temporary capture-source Linode,
-3. wait for readiness,
-4. validate region, tags, and disk presence,
-5. shut down the source Linode,
-6. capture a custom image from the selected disk,
-7. wait for image availability,
-8. delete or preserve the source according to explicit flags.
+2. preflight the requested region, Linode type, and source image with
+   non-mutating API calls,
+3. create a tagged temporary capture-source Linode,
+4. wait for readiness,
+5. validate region, tags, and disk presence,
+6. shut down the source Linode,
+7. capture a custom image from the selected disk,
+8. wait for image availability,
+9. delete or preserve the source according to explicit flags.
 
 Capture validation is provider/API-level only. It verifies region, required
 tags, disk presence, image availability, and image tags from API responses.
@@ -118,10 +120,12 @@ custom image id via `--image-id`, a Linode type, and `LINODE_TOKEN`.
 The execute flow is intentionally linear:
 
 1. preflight the token with non-mutating API calls,
-2. create a tagged temporary deploy Linode from the custom image id,
-3. wait for provider/API-level running status,
-4. validate running status, requested region, and required tags,
-5. delete or preserve the deploy instance according to explicit flags.
+2. preflight the requested region, Linode type, and deploy image with
+   non-mutating API calls,
+3. create a tagged temporary deploy Linode from the custom image id,
+4. wait for provider/API-level running status,
+5. validate running status, requested region, and required tags,
+6. delete or preserve the deploy instance according to explicit flags.
 
 M3 does not perform SSH, cloud-init, service, or application readiness
 validation.
@@ -146,8 +150,9 @@ The execute flow reuses the capture and deploy internals:
 Capture-deploy cleanup is tag-scoped. It only deletes resources carrying all
 required tags for the current run, including the matching component tag.
 Because capture and deploy remain independently reusable, capture-deploy runs
-each phase's non-mutating API preflight. Seeing two `preflight_api_access`
-steps in a combined manifest is expected.
+each phase's non-mutating API preflight, including provider input checks.
+Seeing two `preflight_api_access` and `preflight_provider_inputs` steps in a
+combined manifest is expected.
 
 ## Cleanup Semantics
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -38,6 +38,7 @@ approved environment injection.
 OAuth access that can:
 
 - read the current profile for preflight,
+- read regions, Linode types, and images for input preflight,
 - create, read, shut down, and delete temporary Linodes,
 - create and read custom images,
 - apply tags to created resources.
@@ -73,10 +74,10 @@ preview only; it does not read `LINODE_TOKEN` or call Linode. `cleanup
 
 `capture --execute`, `deploy --execute`, and `capture-deploy --execute` fail
 before mutation if required options or `LINODE_TOKEN` are missing. They perform
-non-mutating token preflight before creating resources. Partial-failure cleanup
-only targets resources whose required tags exactly match the current run.
-Tag mismatches are represented as preserved resources in manifests, not as
-deletion attempts.
+non-mutating token preflight and read-only region, type, and image input
+preflight before creating resources. Partial-failure cleanup only targets
+resources whose required tags exactly match the current run. Tag mismatches are
+represented as preserved resources in manifests, not as deletion attempts.
 
 `capture-deploy --execute` creates resources with `mode=capture-deploy` and a
 component-specific tag: capture resources use `component=capture`, and deploy
@@ -90,7 +91,7 @@ mismatched tags, resources with malformed or unexpired TTL values, and resources
 outside an optional `--run-id` filter. Preserved entries use sanitized reason
 strings and normal stdout redacts provider identifiers.
 
-Validation is limited to provider/API responses: resource state, requested
-region, required tags, disk presence for capture, and image availability for
-capture. It does not perform SSH, cloud-init, service, or application readiness
-checks.
+Validation is limited to provider/API responses: input availability, resource
+state, requested region, required tags, disk presence for capture, and image
+availability for capture. It does not perform SSH, cloud-init, service, or
+application readiness checks.

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -7,7 +7,7 @@ import secrets
 from dataclasses import dataclass
 from typing import Any
 
-from .linode_api import LinodeClient, LinodeClientProtocol
+from .linode_api import LinodeClient, LinodeClientProtocol, LinodePreflightError
 from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
 from .validation_results import finish_validation, record_validation_check, start_validation
 
@@ -124,14 +124,22 @@ def execute_capture(
 
         tags = list(manifest["tags"])
         region = options.regions[0]
+        source_image = required_text(options.source_image)
+        instance_type = required_text(options.instance_type)
         source_label = f"lil-{safe_label_suffix(manifest['run_id'])}-source"
         image_label = options.image_label or f"lil-{safe_label_suffix(manifest['run_id'])}-image"
+
+        append_step(manifest, "preflight_provider_inputs", mutates=False, status="running")
+        run_client.preflight_region(region)
+        run_client.preflight_instance_type(instance_type)
+        run_client.preflight_image(source_image)
+        finish_step(manifest, "preflight_provider_inputs")
 
         append_step(manifest, "create_capture_source", mutates=True, status="running")
         capture_source = run_client.create_instance(
             region=region,
-            source_image=required_text(options.source_image),
-            instance_type=required_text(options.instance_type),
+            source_image=source_image,
+            instance_type=instance_type,
             label=source_label,
             tags=tags,
             root_password=secrets.token_urlsafe(32),
@@ -414,6 +422,6 @@ def safe_label_suffix(value: str) -> str:
 
 
 def safe_error_message(exc: Exception) -> str:
-    if isinstance(exc, CaptureError):
+    if isinstance(exc, (CaptureError, LinodePreflightError)):
         return str(exc)
     return exc.__class__.__name__

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -406,6 +406,10 @@ def required_text(value: object) -> str:
 
 
 def safe_error_message(exc: Exception) -> str:
+    if isinstance(exc, (CaptureError, DeployError)) and exc.manifest is not None:
+        errors = exc.manifest.get("errors", [])
+        if errors:
+            return str(errors[0])
     if isinstance(exc, (CaptureDeployError, CaptureError, DeployError)):
         return str(exc)
     return exc.__class__.__name__

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -7,7 +7,7 @@ import secrets
 from dataclasses import dataclass
 from typing import Any
 
-from .linode_api import LinodeClient, LinodeClientProtocol
+from .linode_api import LinodeClient, LinodeClientProtocol, LinodePreflightError
 from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
 from .validation_results import finish_validation, record_validation_check, start_validation
 
@@ -118,13 +118,21 @@ def execute_deploy(
 
         tags = list(manifest["tags"])
         region = options.regions[0]
+        image_id = required_text(options.image_id)
+        instance_type = required_text(options.instance_type)
         instance_label = f"lil-{safe_label_suffix(manifest['run_id'])}-deploy"
+
+        append_step(manifest, "preflight_provider_inputs", mutates=False, status="running")
+        run_client.preflight_region(region)
+        run_client.preflight_instance_type(instance_type)
+        run_client.preflight_image(image_id)
+        finish_step(manifest, "preflight_provider_inputs")
 
         append_step(manifest, "create_deploy_instance", mutates=True, status="running")
         deploy_instance = run_client.create_instance(
             region=region,
-            source_image=required_text(options.image_id),
-            instance_type=required_text(options.instance_type),
+            source_image=image_id,
+            instance_type=instance_type,
             label=instance_label,
             tags=tags,
             root_password=secrets.token_urlsafe(32),
@@ -331,6 +339,6 @@ def safe_label_suffix(value: str) -> str:
 
 
 def safe_error_message(exc: Exception) -> str:
-    if isinstance(exc, DeployError):
+    if isinstance(exc, (DeployError, LinodePreflightError)):
         return str(exc)
     return exc.__class__.__name__

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -25,8 +25,18 @@ class LinodeTokenError(LinodeApiError):
     """Raised when execute mode lacks a usable Linode token."""
 
 
+class LinodePreflightError(LinodeApiError):
+    """Raised when read-only provider input checks fail."""
+
+
 class LinodeClientProtocol(Protocol):
     def preflight(self) -> None: ...
+
+    def preflight_region(self, region: str) -> None: ...
+
+    def preflight_instance_type(self, instance_type: str) -> None: ...
+
+    def preflight_image(self, image_id: str) -> None: ...
 
     def create_instance(
         self,
@@ -91,6 +101,18 @@ class LinodeClient:
     def preflight(self) -> None:
         self._request("GET", "/profile")
         self._request("GET", "/profile/grants", allow_empty=True)
+
+    def preflight_region(self, region: str) -> None:
+        escaped = quote(region, safe="")
+        self._preflight_resource(f"/regions/{escaped}", "requested region is unavailable")
+
+    def preflight_instance_type(self, instance_type: str) -> None:
+        escaped = quote(instance_type, safe="")
+        self._preflight_resource(f"/linode/types/{escaped}", "requested Linode type is unavailable")
+
+    def preflight_image(self, image_id: str) -> None:
+        escaped = quote(image_id, safe="")
+        self._preflight_resource(f"/images/{escaped}", "requested image is unavailable")
 
     def create_instance(
         self,
@@ -180,6 +202,14 @@ class LinodeClient:
     def delete_instance(self, linode_id: int) -> dict[str, Any]:
         self._request("DELETE", f"/linode/instances/{linode_id}")
         return {"linode_id": linode_id, "deleted": True}
+
+    def _preflight_resource(self, path: str, unavailable_message: str) -> None:
+        try:
+            self._request("GET", path)
+        except LinodeTokenError:
+            raise
+        except LinodeApiError as exc:
+            raise LinodePreflightError(unavailable_message) from exc
 
     def _wait_for_instance_status(self, linode_id: int, statuses: set[str]) -> dict[str, Any]:
         def current() -> dict[str, Any]:

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from linode_image_lab.capture import CaptureError, capture_plan
-from linode_image_lab.linode_api import LinodeTokenError
+from linode_image_lab.linode_api import LinodePreflightError, LinodeTokenError
 from linode_image_lab.manifest import serialize_manifest
 
 
@@ -32,6 +32,15 @@ class FakeLinodeClient:
 
     def preflight(self) -> None:
         self.calls.append("preflight")
+
+    def preflight_region(self, region: str) -> None:
+        self.calls.append("preflight_region")
+
+    def preflight_instance_type(self, instance_type: str) -> None:
+        self.calls.append("preflight_instance_type")
+
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
 
     def create_instance(
         self,
@@ -123,6 +132,12 @@ class InvalidTokenClient(FakeLinodeClient):
         raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
 
 
+class InvalidSourceImageClient(FakeLinodeClient):
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
+        raise LinodePreflightError("requested image is unavailable")
+
+
 class CaptureExecutionTests(unittest.TestCase):
     def test_dry_run_does_not_read_token_or_call_client(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -177,6 +192,33 @@ class CaptureExecutionTests(unittest.TestCase):
         self.assertEqual(client.calls, ["preflight"])
         self.assertEqual(raised.exception.manifest["status"], "failed")
 
+    def test_provider_preflight_fails_before_mutation(self) -> None:
+        client = InvalidSourceImageClient()
+
+        with self.assertRaises(CaptureError) as raised:
+            capture_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="private/invalid-source-image",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertEqual(
+            client.calls,
+            [
+                "preflight",
+                "preflight_region",
+                "preflight_instance_type",
+                "preflight_image",
+            ],
+        )
+        self.assertEqual(raised.exception.manifest["status"], "failed")
+        self.assertEqual(raised.exception.manifest["errors"], ["requested image is unavailable"])
+        self.assertEqual(raised.exception.manifest["resources"], [])
+
     def test_execute_with_fake_client_records_expected_call_order(self) -> None:
         client = FakeLinodeClient()
 
@@ -194,6 +236,9 @@ class CaptureExecutionTests(unittest.TestCase):
             client.calls,
             [
                 "preflight",
+                "preflight_region",
+                "preflight_instance_type",
+                "preflight_image",
                 "create_instance",
                 "wait_instance_ready",
                 "list_disks",

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from linode_image_lab.capture_deploy import CaptureDeployError, capture_deploy_plan
+from linode_image_lab.linode_api import LinodePreflightError
 from linode_image_lab.manifest import serialize_manifest
 
 
@@ -32,6 +33,15 @@ class FakeLinodeClient:
 
     def preflight(self) -> None:
         self.calls.append("preflight")
+
+    def preflight_region(self, region: str) -> None:
+        self.calls.append("preflight_region")
+
+    def preflight_instance_type(self, instance_type: str) -> None:
+        self.calls.append("preflight_instance_type")
+
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
 
     def create_instance(
         self,
@@ -139,6 +149,13 @@ class ExplodingClient:
         raise AssertionError("dry-run must not call the client")
 
 
+class InvalidCapturedImageClient(FakeLinodeClient):
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
+        if image_id == "private/789":
+            raise LinodePreflightError("requested image is unavailable")
+
+
 class CaptureDeployExecutionTests(unittest.TestCase):
     def test_dry_run_does_not_read_token_or_call_execution(self) -> None:
         with (
@@ -210,6 +227,9 @@ class CaptureDeployExecutionTests(unittest.TestCase):
             client.calls,
             [
                 "preflight",
+                "preflight_region",
+                "preflight_instance_type",
+                "preflight_image",
                 "create_capture_source",
                 "wait_capture_source_ready",
                 "list_disks",
@@ -218,6 +238,9 @@ class CaptureDeployExecutionTests(unittest.TestCase):
                 "capture_image",
                 "wait_image_available",
                 "preflight",
+                "preflight_region",
+                "preflight_instance_type",
+                "preflight_image",
                 "create_deploy_instance",
                 "wait_deploy_instance_ready",
                 "delete_capture_source",
@@ -242,6 +265,26 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         )
         self.assertEqual(manifest["cleanup"]["status"], "completed")
         self.assertEqual(client.deleted, [123, 321])
+
+    def test_deploy_provider_preflight_fails_before_deploy_mutation(self) -> None:
+        client = InvalidCapturedImageClient()
+
+        with self.assertRaises(CaptureDeployError) as raised:
+            capture_deploy_plan(
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        self.assertNotIn("create_deploy_instance", client.calls)
+        self.assertIn("delete_capture_source", client.calls)
+        self.assertEqual(raised.exception.manifest["status"], "failed")
+        self.assertEqual(raised.exception.manifest["errors"], ["requested image is unavailable"])
+        self.assertEqual(raised.exception.manifest["deploy"]["resources"], [])
 
     def test_execute_applies_component_tags_to_created_resources(self) -> None:
         client = FakeLinodeClient()

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from linode_image_lab.deploy import DeployError, deploy_plan
-from linode_image_lab.linode_api import LinodeTokenError
+from linode_image_lab.linode_api import LinodePreflightError, LinodeTokenError
 from linode_image_lab.manifest import serialize_manifest
 
 
@@ -32,6 +32,15 @@ class FakeLinodeClient:
 
     def preflight(self) -> None:
         self.calls.append("preflight")
+
+    def preflight_region(self, region: str) -> None:
+        self.calls.append("preflight_region")
+
+    def preflight_instance_type(self, instance_type: str) -> None:
+        self.calls.append("preflight_instance_type")
+
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
 
     def create_instance(
         self,
@@ -103,6 +112,28 @@ class InvalidTokenClient(FakeLinodeClient):
     def preflight(self) -> None:
         self.calls.append("preflight")
         raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
+
+
+class InvalidProviderInputClient(FakeLinodeClient):
+    def __init__(self, *, fail_call: str, message: str) -> None:
+        super().__init__()
+        self.fail_call = fail_call
+        self.message = message
+
+    def preflight_region(self, region: str) -> None:
+        self.calls.append("preflight_region")
+        if self.fail_call == "region":
+            raise LinodePreflightError(self.message)
+
+    def preflight_instance_type(self, instance_type: str) -> None:
+        self.calls.append("preflight_instance_type")
+        if self.fail_call == "instance_type":
+            raise LinodePreflightError(self.message)
+
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
+        if self.fail_call == "image":
+            raise LinodePreflightError(self.message)
 
 
 class DeployExecutionTests(unittest.TestCase):
@@ -181,6 +212,42 @@ class DeployExecutionTests(unittest.TestCase):
         self.assertEqual(client.calls, ["preflight"])
         self.assertEqual(raised.exception.manifest["status"], "failed")
 
+    def test_provider_preflight_region_type_and_image_fail_before_mutation(self) -> None:
+        cases = [
+            ("region", "requested region is unavailable", ["preflight", "preflight_region"]),
+            (
+                "instance_type",
+                "requested Linode type is unavailable",
+                ["preflight", "preflight_region", "preflight_instance_type"],
+            ),
+            (
+                "image",
+                "requested image is unavailable",
+                ["preflight", "preflight_region", "preflight_instance_type", "preflight_image"],
+            ),
+        ]
+
+        for fail_call, message, expected_calls in cases:
+            with self.subTest(fail_call=fail_call):
+                client = InvalidProviderInputClient(fail_call=fail_call, message=message)
+
+                with self.assertRaises(DeployError) as raised:
+                    deploy_plan(
+                        regions=["us-east"],
+                        run_id="run-test",
+                        ttl="2030-01-01T00:00:00Z",
+                        execute=True,
+                        image_id="private/invalid-image",
+                        instance_type="g6-nanode-1",
+                        client=client,
+                    )
+
+                self.assertEqual(client.calls, expected_calls)
+                self.assertNotIn("create_instance", client.calls)
+                self.assertEqual(raised.exception.manifest["status"], "failed")
+                self.assertEqual(raised.exception.manifest["errors"], [message])
+                self.assertEqual(raised.exception.manifest["resources"], [])
+
     def test_execute_with_fake_client_records_expected_call_order(self) -> None:
         client = FakeLinodeClient()
 
@@ -198,6 +265,9 @@ class DeployExecutionTests(unittest.TestCase):
             client.calls,
             [
                 "preflight",
+                "preflight_region",
+                "preflight_instance_type",
+                "preflight_image",
                 "create_instance",
                 "wait_instance_ready",
                 "delete_instance",

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 from urllib.error import HTTPError
 
-from linode_image_lab.linode_api import LinodeApiError, LinodeClient, LinodeTokenError
+from linode_image_lab.linode_api import LinodeApiError, LinodeClient, LinodePreflightError, LinodeTokenError
 
 TOKEN_VALUE = "test-" + "token-value"
 API_BASE_URL = "https://api.example/v4"
@@ -71,6 +71,43 @@ class LinodeClientTests(unittest.TestCase):
         )
         self.assertEqual([request.get_header("Authorization") for request in requests], [f"Bearer {TOKEN_VALUE}"] * 2)
         self.assertEqual(responses, [])
+
+    def test_provider_preflight_helpers_use_read_only_resource_paths(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse({})
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            client.preflight_region("us-east")
+            client.preflight_instance_type("g6-nanode-1")
+            client.preflight_image("linode/debian12")
+
+        self.assertEqual([request.get_method() for request in requests], ["GET", "GET", "GET"])
+        self.assertEqual(
+            [request.full_url for request in requests],
+            [
+                f"{API_BASE_URL}/regions/us-east",
+                f"{API_BASE_URL}/linode/types/g6-nanode-1",
+                f"{API_BASE_URL}/images/linode%2Fdebian12",
+            ],
+        )
+
+    def test_provider_preflight_failure_uses_sanitized_message(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        with patch(
+            "linode_image_lab.linode_api.urlopen",
+            side_effect=self.http_error(404, "missing private/789"),
+        ):
+            with self.assertRaises(LinodePreflightError) as raised:
+                client.preflight_image("private/789")
+
+        self.assertEqual(str(raised.exception), "requested image is unavailable")
+        self.assertNotIn("private/789", str(raised.exception))
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
 
     def test_create_instance_sends_expected_payload_and_maps_response(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)


### PR DESCRIPTION
Closes #17

## Summary
- add read-only Linode provider preflight helpers for regions, types, and images
- run provider input preflight before resource creation in capture, deploy, and capture-deploy execute paths
- keep preflight errors sanitized and covered with fake-client/unit tests
- document the execute sequencing update

## Validation
- make check
- make security-check