### PR TITLE
[codex] Expand validation result manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,10 @@ Modeled resources use rediscoverable tags:
 
 Execute manifests use consistent top-level `status`, `steps`, `resources`,
 `validation`, and `cleanup` fields. For `capture-deploy`, top-level `resources`
-and `cleanup` summarize the combined run, while nested `capture` and `deploy`
-blocks show phase-specific details.
+`validation`, and `cleanup` summarize the combined run, while nested `capture`
+and `deploy` blocks show phase-specific details. Validation checks are objects
+with `name`, `status`, and a symbolic `target`; failed checks include a
+sanitized `failure_reason`.
 
 Cleanup status values are literal: `deleted` means a temporary Linode was
 deleted, `preserved` means a resource was kept or skipped for safety,

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -179,10 +179,15 @@ tags did not match, with a `reason` such as `requested`, `tag_mismatch`, or
 Single-command execute manifests expose top-level `status`, `steps`,
 `resources`, `validation`, and `cleanup`. Capture-deploy keeps the same
 top-level fields and also nests `capture` and `deploy` sections. Top-level
-`resources` is the combined list for the whole run. Nested `capture.resources`
-and `deploy.resources` are phase-specific slices of that same lifecycle.
+`resources` and `validation` summarize the whole run. Nested
+`capture.resources`, `deploy.resources`, `capture.validation`, and
+`deploy.validation` are phase-specific slices of that same lifecycle.
 
 `validation` means provider/API-level checks only: resource state, requested
 region, required tags, disk presence for capture, and image availability for
 capture. It does not include SSH, app health, service readiness, or cloud-init
 completion checks.
+
+Validation checks are structured as stable objects with `name`, `status`, and a
+symbolic `target`. Failed checks include a sanitized `failure_reason`; provider
+resource identifiers are redacted during serialization.

--- a/docs/design.md
+++ b/docs/design.md
@@ -57,11 +57,12 @@ execution adds `execution_mode`, ordered `steps`, `resources`, `deploy_source`,
 execution adds top-level `execution_mode`, `steps`, `resources`, `capture`,
 `deploy`, `validation`, and `cleanup` fields. Top-level `resources` is the
 combined resource list; nested `capture.resources` and `deploy.resources` are
-phase-specific views. Top-level `cleanup` is the combined cleanup summary;
-nested cleanup blocks preserve phase-specific status. Internal manifests may
-carry provider resource identifiers required for cleanup and debugging. Normal
-stdout uses sanitized serialization, which redacts provider identifiers before
-printing.
+phase-specific views. Top-level `validation` and `cleanup` are combined
+summaries; nested validation and cleanup blocks preserve phase-specific status.
+Validation checks record `name`, `status`, a symbolic `target`, and a sanitized
+`failure_reason` when a check fails. Internal manifests may carry provider
+resource identifiers required for cleanup and debugging. Normal stdout uses
+sanitized serialization, which redacts provider identifiers before printing.
 
 ## Config Defaults
 
@@ -136,7 +137,7 @@ The execute flow reuses the capture and deploy internals:
 1. run capture with `mode=capture-deploy` and `component=capture`,
 2. pass the internal custom image id to deploy without exposing it in stdout,
 3. run deploy with `mode=capture-deploy` and `component=deploy`,
-4. surface deploy's provider/API-level validation result,
+4. surface the combined provider/API-level validation summary,
 5. delete the temporary capture-source Linode when its current-run tags match,
 6. delete or preserve the temporary deploy Linode according to
    `--preserve-instance`,

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -9,6 +9,15 @@ from typing import Any
 
 from .linode_api import LinodeClient, LinodeClientProtocol
 from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
+from .validation_results import finish_validation, record_validation_check, start_validation
+
+CAPTURE_VALIDATION_CHECKS = (
+    ("source_region_matches", "capture_source"),
+    ("source_required_tags_match", "capture_source"),
+    ("source_disk_found", "capture_source"),
+    ("custom_image_available", "custom_image"),
+    ("custom_image_required_tags_match", "custom_image"),
+)
 
 
 class CaptureError(ValueError):
@@ -142,19 +151,33 @@ def execute_capture(
         finish_step(manifest, "wait_capture_source_ready")
 
         append_step(manifest, "validate_capture_source_api", mutates=False, status="running")
-        manifest["validation"] = {
-            "status": "running",
-            "checks": [
-                "source_region_matches",
-                "source_required_tags_match",
-                "source_disk_found",
-                "custom_image_available",
-                "custom_image_required_tags_match",
-            ],
-        }
-        validate_created_resource(capture_source, required_tags=tags, region=region)
-        disks = run_client.list_disks(required_int(capture_source.get("linode_id")))
-        disk = first_disk(disks)
+        manifest["validation"] = start_validation(CAPTURE_VALIDATION_CHECKS)
+        record_validation_check(
+            manifest["validation"],
+            "source_region_matches",
+            lambda: validate_resource_region(
+                capture_source,
+                region=region,
+                message="created capture source is not in the requested region",
+            ),
+        )
+        record_validation_check(
+            manifest["validation"],
+            "source_required_tags_match",
+            lambda: validate_required_tags(
+                capture_source,
+                required_tags=tags,
+                message="created resource is missing required capture tags",
+            ),
+        )
+        disk: dict[str, Any] = {}
+
+        def find_source_disk() -> None:
+            nonlocal disk
+            disks = run_client.list_disks(required_int(capture_source.get("linode_id")))
+            disk = first_disk(disks)
+
+        record_validation_check(manifest["validation"], "source_disk_found", find_source_disk)
         capture_source["disk_id"] = disk["disk_id"]
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"][0] = dict(capture_source)
@@ -187,23 +210,27 @@ def execute_capture(
         finish_step(manifest, "create_custom_image")
 
         append_step(manifest, "wait_custom_image_available", mutates=False, status="running")
-        custom_image = merge_resource(
-            custom_image,
-            run_client.wait_image_available(required_text(custom_image.get("image_id"))),
+
+        def wait_for_custom_image() -> None:
+            nonlocal custom_image
+            custom_image = merge_resource(
+                custom_image,
+                run_client.wait_image_available(required_text(custom_image.get("image_id"))),
+            )
+
+        record_validation_check(manifest["validation"], "custom_image_available", wait_for_custom_image)
+        record_validation_check(
+            manifest["validation"],
+            "custom_image_required_tags_match",
+            lambda: validate_required_tags(
+                custom_image,
+                required_tags=tags,
+                message="created resource is missing required capture tags",
+            ),
         )
-        validate_created_resource(custom_image, required_tags=tags)
         manifest["custom_image"] = dict(custom_image)
         manifest["resources"][1] = dict(custom_image)
-        manifest["validation"] = {
-            "status": "succeeded",
-            "checks": [
-                "source_region_matches",
-                "source_required_tags_match",
-                "source_disk_found",
-                "custom_image_available",
-                "custom_image_required_tags_match",
-            ],
-        }
+        finish_validation(manifest["validation"])
         finish_step(manifest, "wait_custom_image_available")
 
         if options.defer_cleanup:
@@ -324,10 +351,27 @@ def validate_created_resource(
     required_tags: list[str],
     region: str | None = None,
 ) -> None:
-    if region is not None and resource.get("region") != region:
-        raise CaptureError("created capture source is not in the requested region")
+    if region is not None:
+        validate_resource_region(
+            resource,
+            region=region,
+            message="created capture source is not in the requested region",
+        )
+    validate_required_tags(
+        resource,
+        required_tags=required_tags,
+        message="created resource is missing required capture tags",
+    )
+
+
+def validate_resource_region(resource: dict[str, Any], *, region: str, message: str) -> None:
+    if resource.get("region") != region:
+        raise CaptureError(message)
+
+
+def validate_required_tags(resource: dict[str, Any], *, required_tags: list[str], message: str) -> None:
     if not has_required_tags(resource, required_tags):
-        raise CaptureError("created resource is missing required capture tags")
+        raise CaptureError(message)
 
 
 def has_required_tags(resource: dict[str, Any], required_tags: list[str]) -> bool:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -19,6 +19,7 @@ from .deploy import (
 )
 from .linode_api import LinodeClient, LinodeClientProtocol
 from .manifest import create_manifest, generate_tags
+from .validation_results import combined_validation
 
 
 class CaptureDeployError(ValueError):
@@ -155,7 +156,10 @@ def execute_capture_deploy(
         sync_manifest(manifest, capture_manifest=capture_manifest, deploy_manifest=deploy_manifest)
 
         append_step(manifest, "record_deploy_validation", mutates=False, status="running")
-        manifest["validation"] = dict(deploy_manifest.get("validation", {}))
+        manifest["validation"] = combined_validation(
+            capture_validation=capture_manifest.get("validation", {}),
+            deploy_validation=deploy_manifest.get("validation", {}),
+        )
         finish_step(manifest, "record_deploy_validation")
 
         append_step(manifest, "cleanup_temporary_resources", mutates=True, status="running")
@@ -311,7 +315,11 @@ def sync_manifest(
             "validation": deploy_manifest.get("validation", {}),
             "cleanup": deploy_manifest.get("cleanup", {}),
         }
-        manifest["validation"] = dict(deploy_manifest.get("validation", manifest["validation"]))
+
+    manifest["validation"] = combined_validation(
+        capture_validation=capture_manifest.get("validation", {}) if capture_manifest is not None else None,
+        deploy_validation=deploy_manifest.get("validation", {}) if deploy_manifest is not None else None,
+    )
 
     resources: list[dict[str, Any]] = []
     if capture_manifest is not None:

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -9,6 +9,13 @@ from typing import Any
 
 from .linode_api import LinodeClient, LinodeClientProtocol
 from .manifest import REQUIRED_TAG_KEYS, create_manifest, tags_to_dict
+from .validation_results import finish_validation, record_validation_check, start_validation
+
+DEPLOY_VALIDATION_CHECKS = (
+    ("instance_running", "deploy_instance"),
+    ("region_matches", "deploy_instance"),
+    ("required_tags_match", "deploy_instance"),
+)
 
 
 class DeployError(ValueError):
@@ -137,23 +144,23 @@ def execute_deploy(
         finish_step(manifest, "wait_deploy_instance_ready")
 
         append_step(manifest, "validate_deploy_instance_api", mutates=False, status="running")
-        manifest["validation"] = {
-            "status": "running",
-            "checks": [
-                "instance_running",
-                "region_matches",
-                "required_tags_match",
-            ],
-        }
-        validate_deploy_instance(deploy_instance, required_tags=tags, region=region)
-        manifest["validation"] = {
-            "status": "succeeded",
-            "checks": [
-                "instance_running",
-                "region_matches",
-                "required_tags_match",
-            ],
-        }
+        manifest["validation"] = start_validation(DEPLOY_VALIDATION_CHECKS)
+        record_validation_check(
+            manifest["validation"],
+            "region_matches",
+            lambda: validate_instance_region(deploy_instance, region),
+        )
+        record_validation_check(
+            manifest["validation"],
+            "instance_running",
+            lambda: validate_instance_running(deploy_instance),
+        )
+        record_validation_check(
+            manifest["validation"],
+            "required_tags_match",
+            lambda: validate_required_tags(deploy_instance, required_tags=tags),
+        )
+        finish_validation(manifest["validation"])
         finish_step(manifest, "validate_deploy_instance_api")
 
         if options.defer_cleanup:
@@ -274,10 +281,22 @@ def validate_deploy_instance(
     required_tags: list[str],
     region: str,
 ) -> None:
+    validate_instance_region(resource, region)
+    validate_instance_running(resource)
+    validate_required_tags(resource, required_tags=required_tags)
+
+
+def validate_instance_region(resource: dict[str, Any], region: str) -> None:
     if resource.get("region") != region:
         raise DeployError("created deploy instance is not in the requested region")
+
+
+def validate_instance_running(resource: dict[str, Any]) -> None:
     if resource.get("status") != "running":
         raise DeployError("created deploy instance is not running")
+
+
+def validate_required_tags(resource: dict[str, Any], *, required_tags: list[str]) -> None:
     if not has_required_tags(resource, required_tags):
         raise DeployError("created resource is missing required deploy tags")
 

--- a/src/linode_image_lab/validation_results.py
+++ b/src/linode_image_lab/validation_results.py
@@ -1,0 +1,100 @@
+"""Structured validation result helpers for execute manifests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from .redaction import redact_text
+
+CheckSpec = tuple[str, str]
+
+
+def start_validation(checks: Iterable[CheckSpec]) -> dict[str, Any]:
+    return {"status": "running", "checks": [check_result(name, target, "pending") for name, target in checks]}
+
+
+def check_result(name: str, target: str, status: str) -> dict[str, str]:
+    return {"name": name, "status": status, "target": target}
+
+
+def record_validation_check(validation: dict[str, Any], name: str, check: Callable[[], None]) -> None:
+    try:
+        check()
+    except Exception as exc:
+        mark_validation_check_failed(validation, name, safe_failure_reason(exc))
+        raise
+    mark_validation_check_succeeded(validation, name)
+
+
+def mark_validation_check_succeeded(validation: dict[str, Any], name: str) -> None:
+    for check in validation.get("checks", []):
+        if check.get("name") == name:
+            check["status"] = "succeeded"
+            return
+
+
+def mark_validation_check_failed(validation: dict[str, Any], name: str, failure_reason: str) -> None:
+    validation["status"] = "failed"
+    for check in validation.get("checks", []):
+        if check.get("name") == name:
+            check["status"] = "failed"
+            check["failure_reason"] = failure_reason
+            return
+
+
+def finish_validation(validation: dict[str, Any]) -> None:
+    if validation.get("status") == "failed":
+        return
+    validation["status"] = "succeeded"
+
+
+def combined_validation(
+    *,
+    capture_validation: dict[str, Any] | None,
+    deploy_validation: dict[str, Any] | None,
+) -> dict[str, Any]:
+    validations = [
+        validation
+        for validation in (
+            prefixed_validation(capture_validation, "capture"),
+            prefixed_validation(deploy_validation, "deploy"),
+        )
+        if validation is not None
+    ]
+    if not validations:
+        return {"status": "not_started", "checks": []}
+
+    checks: list[dict[str, Any]] = []
+    statuses: list[str] = []
+    for validation in validations:
+        statuses.append(str(validation.get("status", "not_started")))
+        checks.extend(validation.get("checks", []))
+
+    if any(status == "failed" for status in statuses):
+        status = "failed"
+    elif all(status == "succeeded" for status in statuses):
+        status = "succeeded"
+    elif any(status == "running" for status in statuses):
+        status = "running"
+    else:
+        status = "not_started"
+    return {"status": status, "checks": checks}
+
+
+def prefixed_validation(validation: dict[str, Any] | None, prefix: str) -> dict[str, Any] | None:
+    if validation is None:
+        return None
+    checks = []
+    for check in validation.get("checks", []):
+        copied = dict(check)
+        target = str(copied.get("target", "validation"))
+        copied["target"] = f"{prefix}.{target}"
+        checks.append(copied)
+    return {"status": validation.get("status", "not_started"), "checks": checks}
+
+
+def safe_failure_reason(exc: Exception) -> str:
+    if isinstance(exc, ValueError):
+        return redact_text(str(exc))
+    return exc.__class__.__name__

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -10,6 +10,18 @@ from linode_image_lab.linode_api import LinodeTokenError
 from linode_image_lab.manifest import serialize_manifest
 
 
+def validation_check(manifest: dict[str, object], name: str) -> dict[str, object]:
+    validation = manifest["validation"]
+    assert isinstance(validation, dict)
+    checks = validation["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check.get("name") == name:
+            return check
+    raise AssertionError(f"missing validation check: {name}")
+
+
 class FakeLinodeClient:
     def __init__(self, *, missing_create_tags: bool = False) -> None:
         self.calls: list[str] = []
@@ -197,6 +209,16 @@ class CaptureExecutionTests(unittest.TestCase):
         self.assertEqual(manifest["custom_image"]["image_id"], "private/789")
         self.assertEqual(manifest["cleanup"]["status"], "deleted")
         self.assertEqual(manifest["validation"]["status"], "succeeded")
+        self.assertEqual(
+            manifest["validation"]["checks"],
+            [
+                {"name": "source_region_matches", "status": "succeeded", "target": "capture_source"},
+                {"name": "source_required_tags_match", "status": "succeeded", "target": "capture_source"},
+                {"name": "source_disk_found", "status": "succeeded", "target": "capture_source"},
+                {"name": "custom_image_available", "status": "succeeded", "target": "custom_image"},
+                {"name": "custom_image_required_tags_match", "status": "succeeded", "target": "custom_image"},
+            ],
+        )
 
     def test_execute_applies_required_tags_to_created_resources(self) -> None:
         client = FakeLinodeClient()
@@ -254,6 +276,17 @@ class CaptureExecutionTests(unittest.TestCase):
         self.assertIsNotNone(raised.exception.manifest)
         self.assertEqual(raised.exception.manifest["cleanup"]["status"], "preserved")
         self.assertEqual(raised.exception.manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+        self.assertEqual(raised.exception.manifest["validation"]["status"], "failed")
+        self.assertEqual(
+            validation_check(raised.exception.manifest, "source_required_tags_match"),
+            {
+                "name": "source_required_tags_match",
+                "status": "failed",
+                "target": "capture_source",
+                "failure_reason": "created resource is missing required capture tags",
+            },
+        )
+        self.assertEqual(validation_check(raised.exception.manifest, "source_disk_found")["status"], "pending")
 
     def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
         manifest = capture_plan(

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -9,6 +9,18 @@ from linode_image_lab.capture_deploy import CaptureDeployError, capture_deploy_p
 from linode_image_lab.manifest import serialize_manifest
 
 
+def validation_check(manifest: dict[str, object], name: str, target: str) -> dict[str, object]:
+    validation = manifest["validation"]
+    assert isinstance(validation, dict)
+    checks = validation["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check.get("name") == name and check.get("target") == target:
+            return check
+    raise AssertionError(f"missing validation check: {name} target={target}")
+
+
 class FakeLinodeClient:
     def __init__(self, *, missing_deploy_tags: bool = False) -> None:
         self.calls: list[str] = []
@@ -217,6 +229,17 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         self.assertEqual(manifest["capture"]["validation"]["status"], "succeeded")
         self.assertEqual(manifest["deploy"]["deploy_source"]["image_id"], "private/789")
         self.assertEqual(manifest["validation"]["status"], "succeeded")
+        self.assertEqual(manifest["capture"]["validation"]["checks"][0]["target"], "capture_source")
+        self.assertEqual(manifest["deploy"]["validation"]["checks"][0]["target"], "deploy_instance")
+        self.assertEqual(len(manifest["validation"]["checks"]), 8)
+        self.assertEqual(
+            validation_check(manifest, "custom_image_available", "capture.custom_image"),
+            {"name": "custom_image_available", "status": "succeeded", "target": "capture.custom_image"},
+        )
+        self.assertEqual(
+            validation_check(manifest, "required_tags_match", "deploy.deploy_instance"),
+            {"name": "required_tags_match", "status": "succeeded", "target": "deploy.deploy_instance"},
+        )
         self.assertEqual(manifest["cleanup"]["status"], "completed")
         self.assertEqual(client.deleted, [123, 321])
 
@@ -275,6 +298,16 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         self.assertIsNotNone(raised.exception.manifest)
         self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["status"], "preserved")
         self.assertEqual(raised.exception.manifest["deploy"]["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+        self.assertEqual(raised.exception.manifest["validation"]["status"], "failed")
+        self.assertEqual(
+            validation_check(raised.exception.manifest, "required_tags_match", "deploy.deploy_instance"),
+            {
+                "name": "required_tags_match",
+                "status": "failed",
+                "target": "deploy.deploy_instance",
+                "failure_reason": "created resource is missing required deploy tags",
+            },
+        )
 
     def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
         manifest = capture_deploy_plan(

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -10,6 +10,18 @@ from linode_image_lab.linode_api import LinodeTokenError
 from linode_image_lab.manifest import serialize_manifest
 
 
+def validation_check(manifest: dict[str, object], name: str) -> dict[str, object]:
+    validation = manifest["validation"]
+    assert isinstance(validation, dict)
+    checks = validation["checks"]
+    assert isinstance(checks, list)
+    for check in checks:
+        assert isinstance(check, dict)
+        if check.get("name") == name:
+            return check
+    raise AssertionError(f"missing validation check: {name}")
+
+
 class FakeLinodeClient:
     def __init__(self, *, missing_create_tags: bool = False, status: str = "running") -> None:
         self.calls: list[str] = []
@@ -194,6 +206,14 @@ class DeployExecutionTests(unittest.TestCase):
         self.assertEqual(manifest["status"], "succeeded")
         self.assertEqual(manifest["deploy_instance"]["linode_id"], 321)
         self.assertEqual(manifest["validation"]["status"], "succeeded")
+        self.assertEqual(
+            manifest["validation"]["checks"],
+            [
+                {"name": "instance_running", "status": "succeeded", "target": "deploy_instance"},
+                {"name": "region_matches", "status": "succeeded", "target": "deploy_instance"},
+                {"name": "required_tags_match", "status": "succeeded", "target": "deploy_instance"},
+            ],
+        )
         self.assertEqual(manifest["cleanup"]["status"], "deleted")
 
     def test_execute_applies_required_tags_to_created_resource(self) -> None:
@@ -251,6 +271,16 @@ class DeployExecutionTests(unittest.TestCase):
         self.assertIsNotNone(raised.exception.manifest)
         self.assertEqual(raised.exception.manifest["cleanup"]["status"], "preserved")
         self.assertEqual(raised.exception.manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+        self.assertEqual(raised.exception.manifest["validation"]["status"], "failed")
+        self.assertEqual(
+            validation_check(raised.exception.manifest, "required_tags_match"),
+            {
+                "name": "required_tags_match",
+                "status": "failed",
+                "target": "deploy_instance",
+                "failure_reason": "created resource is missing required deploy tags",
+            },
+        )
 
     def test_partial_failure_deletes_tagged_resource_by_default(self) -> None:
         client = FakeLinodeClient(status="offline")
@@ -269,6 +299,15 @@ class DeployExecutionTests(unittest.TestCase):
         self.assertEqual(client.deleted, [321])
         self.assertIsNotNone(raised.exception.manifest)
         self.assertEqual(raised.exception.manifest["cleanup"]["status"], "deleted")
+        self.assertEqual(
+            validation_check(raised.exception.manifest, "instance_running"),
+            {
+                "name": "instance_running",
+                "status": "failed",
+                "target": "deploy_instance",
+                "failure_reason": "created deploy instance is not running",
+            },
+        )
 
     def test_serialized_execute_manifest_redacts_provider_ids(self) -> None:
         manifest = deploy_plan(

--- a/tests/unit/test_validation_results.py
+++ b/tests/unit/test_validation_results.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import unittest
+
+from linode_image_lab.redaction import REDACTION
+from linode_image_lab.validation_results import (
+    combined_validation,
+    record_validation_check,
+    start_validation,
+)
+
+
+class ValidationResultsTests(unittest.TestCase):
+    def test_failed_check_records_sanitized_failure_reason(self) -> None:
+        validation = start_validation((("api_check", "provider_resource"),))
+
+        with self.assertRaises(ValueError):
+            record_validation_check(
+                validation,
+                "api_check",
+                lambda: raise_value_error("token=abcdefgh123456"),
+            )
+
+        self.assertEqual(validation["status"], "failed")
+        self.assertEqual(
+            validation["checks"][0],
+            {
+                "name": "api_check",
+                "status": "failed",
+                "target": "provider_resource",
+                "failure_reason": f"token={REDACTION}",
+            },
+        )
+
+    def test_combined_validation_prefixes_symbolic_targets(self) -> None:
+        capture_validation = {
+            "status": "succeeded",
+            "checks": [{"name": "source_disk_found", "status": "succeeded", "target": "capture_source"}],
+        }
+        deploy_validation = {
+            "status": "failed",
+            "checks": [{"name": "required_tags_match", "status": "failed", "target": "deploy_instance"}],
+        }
+
+        validation = combined_validation(capture_validation=capture_validation, deploy_validation=deploy_validation)
+
+        self.assertEqual(validation["status"], "failed")
+        self.assertEqual(validation["checks"][0]["target"], "capture.capture_source")
+        self.assertEqual(validation["checks"][1]["target"], "deploy.deploy_instance")
+
+
+def raise_value_error(message: str) -> None:
+    raise ValueError(message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replace validation check-name lists with structured check results containing `name`, `status`, and symbolic `target` fields.
- Record sanitized `failure_reason` values for failed validation checks without changing provider preflight, API client, retry, SSH, or app-check behavior.
- Summarize capture-deploy top-level validation across capture and deploy phases while preserving phase-specific nested validation blocks.
- Update tests and docs for the new stable manifest contract.

Closes #19

## Validation

- `make check`
- `make security-check`