### PR TITLE
[codex] Add bounded Linode API retries

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -43,6 +43,18 @@ cleanup as a first-class outcome.
 - `redaction.py` owns recursive output sanitization.
 - `linode_api.py` owns the mockable Linode client boundary.
 
+## Linode API Retry Boundary
+
+The Linode API client retries only safe operation classes: non-mutating GET
+preflight reads, polling GET reads, list/read validation calls, managed Linode
+discovery, and cleanup DELETE attempts for already-selected tagged temporary
+Linodes. Retries are bounded, use deterministic backoff without jitter, and
+record public-safe retry event metadata without tokens or provider identifiers.
+
+Create-instance, image-create, shutdown, and other mutation requests remain
+single-attempt so transient failures cannot create duplicate resources or repeat
+unsafe state transitions.
+
 ## Manifest Foundation
 
 Manifests are plain JSON-compatible dictionaries. They include schema version,

--- a/docs/security.md
+++ b/docs/security.md
@@ -91,6 +91,12 @@ mismatched tags, resources with malformed or unexpired TTL values, and resources
 outside an optional `--run-id` filter. Preserved entries use sanitized reason
 strings and normal stdout redacts provider identifiers.
 
+Transient Linode API retries are limited to read-only API calls, polling reads,
+managed Linode discovery, and cleanup DELETE attempts for eligible tagged
+temporary Linodes. Create-instance, image-create, and shutdown requests are not
+retried automatically. Retry errors and metadata use public-safe operation names
+and status categories rather than tokens or provider identifiers.
+
 Validation is limited to provider/API responses: input availability, resource
 state, requested region, required tags, disk presence for capture, and image
 availability for capture. It does not perform SSH, cloud-init, service, or

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -120,7 +120,7 @@ def execute_capture(
     try:
         append_step(manifest, "preflight_api_access", mutates=False, status="running")
         run_client.preflight()
-        finish_step(manifest, "preflight_api_access")
+        finish_step(manifest, "preflight_api_access", client=run_client)
 
         tags = list(manifest["tags"])
         region = options.regions[0]
@@ -133,7 +133,7 @@ def execute_capture(
         run_client.preflight_region(region)
         run_client.preflight_instance_type(instance_type)
         run_client.preflight_image(source_image)
-        finish_step(manifest, "preflight_provider_inputs")
+        finish_step(manifest, "preflight_provider_inputs", client=run_client)
 
         append_step(manifest, "create_capture_source", mutates=True, status="running")
         capture_source = run_client.create_instance(
@@ -147,7 +147,7 @@ def execute_capture(
         capture_source["resource_type"] = "linode"
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"].append(dict(capture_source))
-        finish_step(manifest, "create_capture_source")
+        finish_step(manifest, "create_capture_source", client=run_client)
 
         append_step(manifest, "wait_capture_source_ready", mutates=False, status="running")
         capture_source = merge_resource(
@@ -156,7 +156,7 @@ def execute_capture(
         )
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"][0] = dict(capture_source)
-        finish_step(manifest, "wait_capture_source_ready")
+        finish_step(manifest, "wait_capture_source_ready", client=run_client)
 
         append_step(manifest, "validate_capture_source_api", mutates=False, status="running")
         manifest["validation"] = start_validation(CAPTURE_VALIDATION_CHECKS)
@@ -189,11 +189,11 @@ def execute_capture(
         capture_source["disk_id"] = disk["disk_id"]
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"][0] = dict(capture_source)
-        finish_step(manifest, "validate_capture_source_api")
+        finish_step(manifest, "validate_capture_source_api", client=run_client)
 
         append_step(manifest, "shutdown_capture_source", mutates=True, status="running")
         run_client.shutdown_instance(required_int(capture_source.get("linode_id")))
-        finish_step(manifest, "shutdown_capture_source")
+        finish_step(manifest, "shutdown_capture_source", client=run_client)
 
         append_step(manifest, "wait_capture_source_offline", mutates=False, status="running")
         capture_source = merge_resource(
@@ -202,7 +202,7 @@ def execute_capture(
         )
         manifest["capture_source"] = dict(capture_source)
         manifest["resources"][0] = dict(capture_source)
-        finish_step(manifest, "wait_capture_source_offline")
+        finish_step(manifest, "wait_capture_source_offline", client=run_client)
 
         append_step(manifest, "create_custom_image", mutates=True, status="running")
         custom_image = run_client.capture_image(
@@ -215,7 +215,7 @@ def execute_capture(
         custom_image["resource_type"] = "image"
         manifest["custom_image"] = dict(custom_image)
         manifest["resources"].append(dict(custom_image))
-        finish_step(manifest, "create_custom_image")
+        finish_step(manifest, "create_custom_image", client=run_client)
 
         append_step(manifest, "wait_custom_image_available", mutates=False, status="running")
 
@@ -239,7 +239,7 @@ def execute_capture(
         manifest["custom_image"] = dict(custom_image)
         manifest["resources"][1] = dict(custom_image)
         finish_validation(manifest["validation"])
-        finish_step(manifest, "wait_custom_image_available")
+        finish_step(manifest, "wait_custom_image_available", client=run_client)
 
         if options.defer_cleanup:
             manifest["cleanup"] = {"status": "deferred", "deleted": [], "preserved": []}
@@ -254,7 +254,7 @@ def execute_capture(
         manifest["status"] = "succeeded"
         return manifest
     except Exception as exc:
-        mark_running_step_failed(manifest)
+        mark_running_step_failed(manifest, client=run_client)
         manifest["status"] = "failed"
         manifest["errors"] = [safe_error_message(exc)]
         if capture_source is not None and not cleanup_started(manifest):
@@ -267,7 +267,7 @@ def execute_capture(
                     required_tags=list(manifest["tags"]),
                 )
             except Exception:
-                mark_running_step_failed(manifest)
+                mark_running_step_failed(manifest, client=run_client)
                 manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
         if manifest.get("validation", {}).get("status") == "running":
             manifest["validation"]["status"] = "failed"
@@ -318,7 +318,7 @@ def cleanup_capture_source(
             {"resource_type": "linode", "linode_id": capture_source.get("linode_id"), "reason": "tag_mismatch"}
         )
     manifest["cleanup"] = cleanup
-    finish_step(manifest, "cleanup_capture_source")
+    finish_step(manifest, "cleanup_capture_source", client=client)
 
 
 def append_step(
@@ -335,18 +335,29 @@ def append_step(
     manifest["steps"].append(step)
 
 
-def finish_step(manifest: dict[str, Any], name: str) -> None:
+def finish_step(manifest: dict[str, Any], name: str, *, client: object | None = None) -> None:
     for step in reversed(manifest["steps"]):
         if step["name"] == name:
+            attach_retry_events(step, client)
             step["status"] = "succeeded"
             return
 
 
-def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+def mark_running_step_failed(manifest: dict[str, Any], *, client: object | None = None) -> None:
     for step in reversed(manifest.get("steps", [])):
         if step.get("status") == "running":
+            attach_retry_events(step, client)
             step["status"] = "failed"
             return
+
+
+def attach_retry_events(step: dict[str, Any], client: object | None) -> None:
+    consume = getattr(client, "consume_retry_events", None)
+    if not callable(consume):
+        return
+    retry_events = consume()
+    if retry_events:
+        step["api_retries"] = retry_events
 
 
 def cleanup_started(manifest: dict[str, Any]) -> bool:

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -92,12 +92,12 @@ def cleanup_plan(
     try:
         append_step(manifest, "preflight_api_access", mutates=False, status="running")
         run_client.preflight()
-        finish_step(manifest, "preflight_api_access")
+        finish_step(manifest, "preflight_api_access", client=run_client)
 
         append_step(manifest, "discover_managed_linodes", mutates=False, status="running")
         resources = run_client.list_managed_linodes()
         manifest["resources"] = [resource_summary(resource) for resource in resources]
-        finish_step(manifest, "discover_managed_linodes")
+        finish_step(manifest, "discover_managed_linodes", client=run_client)
 
         assessments = assess_cleanup(resources, run_id=run_id, now=now)
         manifest["cleanup_candidates"] = [item["resource"] for item in assessments if item["action"] == "delete"]
@@ -128,10 +128,10 @@ def cleanup_plan(
         manifest["cleanup"]["status"] = "completed"
         manifest["status"] = "succeeded"
         manifest["discovery"] = {"status": "completed"}
-        finish_step(manifest, "delete_expired_linodes")
+        finish_step(manifest, "delete_expired_linodes", client=run_client)
         return manifest
     except Exception as exc:
-        mark_running_step_failed(manifest)
+        mark_running_step_failed(manifest, client=run_client)
         manifest["status"] = "failed"
         manifest["cleanup"]["status"] = "failed"
         manifest["errors"] = [safe_error_message(exc)]
@@ -227,18 +227,29 @@ def append_step(
     manifest["steps"].append({"name": name, "mutates": mutates, "status": status})
 
 
-def finish_step(manifest: dict[str, Any], name: str) -> None:
+def finish_step(manifest: dict[str, Any], name: str, *, client: object | None = None) -> None:
     for step in reversed(manifest["steps"]):
         if step["name"] == name:
+            attach_retry_events(step, client)
             step["status"] = "succeeded"
             return
 
 
-def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+def mark_running_step_failed(manifest: dict[str, Any], *, client: object | None = None) -> None:
     for step in reversed(manifest.get("steps", [])):
         if step.get("status") == "running":
+            attach_retry_events(step, client)
             step["status"] = "failed"
             return
+
+
+def attach_retry_events(step: dict[str, Any], client: object | None) -> None:
+    consume = getattr(client, "consume_retry_events", None)
+    if not callable(consume):
+        return
+    retry_events = consume()
+    if retry_events:
+        step["api_retries"] = retry_events
 
 
 def safe_error_message(exc: Exception) -> str:

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -114,7 +114,7 @@ def execute_deploy(
     try:
         append_step(manifest, "preflight_api_access", mutates=False, status="running")
         run_client.preflight()
-        finish_step(manifest, "preflight_api_access")
+        finish_step(manifest, "preflight_api_access", client=run_client)
 
         tags = list(manifest["tags"])
         region = options.regions[0]
@@ -126,7 +126,7 @@ def execute_deploy(
         run_client.preflight_region(region)
         run_client.preflight_instance_type(instance_type)
         run_client.preflight_image(image_id)
-        finish_step(manifest, "preflight_provider_inputs")
+        finish_step(manifest, "preflight_provider_inputs", client=run_client)
 
         append_step(manifest, "create_deploy_instance", mutates=True, status="running")
         deploy_instance = run_client.create_instance(
@@ -140,7 +140,7 @@ def execute_deploy(
         deploy_instance["resource_type"] = "linode"
         manifest["deploy_instance"] = dict(deploy_instance)
         manifest["resources"].append(dict(deploy_instance))
-        finish_step(manifest, "create_deploy_instance")
+        finish_step(manifest, "create_deploy_instance", client=run_client)
 
         append_step(manifest, "wait_deploy_instance_ready", mutates=False, status="running")
         deploy_instance = merge_resource(
@@ -149,7 +149,7 @@ def execute_deploy(
         )
         manifest["deploy_instance"] = dict(deploy_instance)
         manifest["resources"][0] = dict(deploy_instance)
-        finish_step(manifest, "wait_deploy_instance_ready")
+        finish_step(manifest, "wait_deploy_instance_ready", client=run_client)
 
         append_step(manifest, "validate_deploy_instance_api", mutates=False, status="running")
         manifest["validation"] = start_validation(DEPLOY_VALIDATION_CHECKS)
@@ -169,7 +169,7 @@ def execute_deploy(
             lambda: validate_required_tags(deploy_instance, required_tags=tags),
         )
         finish_validation(manifest["validation"])
-        finish_step(manifest, "validate_deploy_instance_api")
+        finish_step(manifest, "validate_deploy_instance_api", client=run_client)
 
         if options.defer_cleanup:
             manifest["cleanup"] = {"status": "deferred", "deleted": [], "preserved": []}
@@ -184,7 +184,7 @@ def execute_deploy(
         manifest["status"] = "succeeded"
         return manifest
     except Exception as exc:
-        mark_running_step_failed(manifest)
+        mark_running_step_failed(manifest, client=run_client)
         manifest["status"] = "failed"
         manifest["errors"] = [safe_error_message(exc)]
         if deploy_instance is not None and not cleanup_started(manifest):
@@ -197,7 +197,7 @@ def execute_deploy(
                     required_tags=list(manifest["tags"]),
                 )
             except Exception:
-                mark_running_step_failed(manifest)
+                mark_running_step_failed(manifest, client=run_client)
                 manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
         if manifest.get("validation", {}).get("status") == "running":
             manifest["validation"]["status"] = "failed"
@@ -248,7 +248,7 @@ def cleanup_deploy_instance(
             {"resource_type": "linode", "linode_id": deploy_instance.get("linode_id"), "reason": "tag_mismatch"}
         )
     manifest["cleanup"] = cleanup
-    finish_step(manifest, "cleanup_deploy_instance")
+    finish_step(manifest, "cleanup_deploy_instance", client=client)
 
 
 def append_step(
@@ -265,18 +265,29 @@ def append_step(
     manifest["steps"].append(step)
 
 
-def finish_step(manifest: dict[str, Any], name: str) -> None:
+def finish_step(manifest: dict[str, Any], name: str, *, client: object | None = None) -> None:
     for step in reversed(manifest["steps"]):
         if step["name"] == name:
+            attach_retry_events(step, client)
             step["status"] = "succeeded"
             return
 
 
-def mark_running_step_failed(manifest: dict[str, Any]) -> None:
+def mark_running_step_failed(manifest: dict[str, Any], *, client: object | None = None) -> None:
     for step in reversed(manifest.get("steps", [])):
         if step.get("status") == "running":
+            attach_retry_events(step, client)
             step["status"] = "failed"
             return
+
+
+def attach_retry_events(step: dict[str, Any], client: object | None) -> None:
+    consume = getattr(client, "consume_retry_events", None)
+    if not callable(consume):
+        return
+    retry_events = consume()
+    if retry_events:
+        step["api_retries"] = retry_events
 
 
 def cleanup_started(manifest: dict[str, Any]) -> bool:

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -15,6 +15,8 @@ from .manifest import PROJECT, tags_to_dict
 
 TOKEN_ENV_NAME = "LINODE_TOKEN"
 DEFAULT_API_BASE_URL = "https://api.linode.com/v4"
+DEFAULT_RETRY_BACKOFF_SECONDS = (0.5, 1.0)
+RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 
 
 class LinodeApiError(ValueError):
@@ -83,6 +85,9 @@ class LinodeClient:
     timeout_seconds: float = 30
     poll_interval_seconds: float = 5
     max_wait_seconds: float = 900
+    max_retry_attempts: int = 3
+    retry_backoff_seconds: tuple[float, ...] = DEFAULT_RETRY_BACKOFF_SECONDS
+    retry_events: list[dict[str, Any]] = field(default_factory=list, repr=False, compare=False)
 
     @classmethod
     def from_env(
@@ -99,8 +104,8 @@ class LinodeClient:
         return cls(token=token)
 
     def preflight(self) -> None:
-        self._request("GET", "/profile")
-        self._request("GET", "/profile/grants", allow_empty=True)
+        self._request("GET", "/profile", retry=True, operation="preflight_profile")
+        self._request("GET", "/profile/grants", allow_empty=True, retry=True, operation="preflight_grants")
 
     def preflight_region(self, region: str) -> None:
         escaped = quote(region, safe="")
@@ -140,7 +145,7 @@ class LinodeClient:
         return self._wait_for_instance_status(linode_id, {"running"})
 
     def list_disks(self, linode_id: int) -> list[dict[str, Any]]:
-        response = self._request("GET", f"/linode/instances/{linode_id}/disks")
+        response = self._request("GET", f"/linode/instances/{linode_id}/disks", retry=True, operation="list_disks")
         disks = response.get("data", []) if isinstance(response, dict) else []
         return [disk for disk in disks if isinstance(disk, dict)]
 
@@ -174,7 +179,7 @@ class LinodeClient:
         escaped = quote(image_id, safe="")
 
         def current() -> dict[str, Any]:
-            response = self._request("GET", f"/images/{escaped}")
+            response = self._request("GET", f"/images/{escaped}", retry=True, operation="poll_image")
             return self._image_resource(response)
 
         return self._wait_until(current, lambda resource: resource.get("status") == "available")
@@ -184,7 +189,7 @@ class LinodeClient:
         page = 1
         while True:
             query = urlencode({"page": page, "page_size": 100})
-            response = self._request("GET", f"/linode/instances?{query}")
+            response = self._request("GET", f"/linode/instances?{query}", retry=True, operation="list_managed_linodes")
             data = response.get("data", []) if isinstance(response, dict) else []
             for item in data:
                 if not isinstance(item, dict):
@@ -200,12 +205,12 @@ class LinodeClient:
             page += 1
 
     def delete_instance(self, linode_id: int) -> dict[str, Any]:
-        self._request("DELETE", f"/linode/instances/{linode_id}")
+        self._request("DELETE", f"/linode/instances/{linode_id}", retry=True, operation="delete_instance")
         return {"linode_id": linode_id, "deleted": True}
 
     def _preflight_resource(self, path: str, unavailable_message: str) -> None:
         try:
-            self._request("GET", path)
+            self._request("GET", path, retry=True, operation="preflight_resource")
         except LinodeTokenError:
             raise
         except LinodeApiError as exc:
@@ -213,7 +218,7 @@ class LinodeClient:
 
     def _wait_for_instance_status(self, linode_id: int, statuses: set[str]) -> dict[str, Any]:
         def current() -> dict[str, Any]:
-            response = self._request("GET", f"/linode/instances/{linode_id}")
+            response = self._request("GET", f"/linode/instances/{linode_id}", retry=True, operation="poll_instance")
             return self._instance_resource(response)
 
         return self._wait_until(current, lambda resource: str(resource.get("status")) in statuses)
@@ -239,28 +244,53 @@ class LinodeClient:
         payload: dict[str, Any] | None = None,
         *,
         allow_empty: bool = False,
+        retry: bool = False,
+        operation: str | None = None,
     ) -> dict[str, Any]:
         body = None if payload is None else json.dumps(payload).encode("utf-8")
-        request = Request(
-            f"{self.api_base_url}{path}",
-            data=body,
-            method=method,
-            headers={
-                "Accept": "application/json",
-                "Authorization": f"Bearer {self.token}",
-                "Content-Type": "application/json",
-            },
-        )
+        attempts = self._retry_attempt_limit(retry)
+        for attempt in range(1, attempts + 1):
+            request = Request(
+                f"{self.api_base_url}{path}",
+                data=body,
+                method=method,
+                headers={
+                    "Accept": "application/json",
+                    "Authorization": f"Bearer {self.token}",
+                    "Content-Type": "application/json",
+                },
+            )
 
-        try:
-            with urlopen(request, timeout=self.timeout_seconds) as response:
-                text = response.read().decode("utf-8")
-        except HTTPError as exc:
-            if exc.code in {401, 403}:
-                raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API") from exc
-            raise LinodeApiError(f"Linode API request failed with status {exc.code}") from exc
-        except OSError as exc:
-            raise LinodeApiError("Linode API request failed") from exc
+            try:
+                with urlopen(request, timeout=self.timeout_seconds) as response:
+                    text = response.read().decode("utf-8")
+                break
+            except HTTPError as exc:
+                if exc.code in {401, 403}:
+                    raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API") from exc
+                if self._should_retry_status(exc.code, attempt=attempt, attempts=attempts):
+                    self._record_retry_event(
+                        method=method,
+                        operation=operation,
+                        attempt=attempt,
+                        attempts=attempts,
+                        reason=f"status_{exc.code}",
+                    )
+                    self._sleep_before_retry(attempt)
+                    continue
+                raise LinodeApiError(self._failure_message(f"Linode API request failed with status {exc.code}", attempt)) from exc
+            except OSError as exc:
+                if attempt < attempts:
+                    self._record_retry_event(
+                        method=method,
+                        operation=operation,
+                        attempt=attempt,
+                        attempts=attempts,
+                        reason=exc.__class__.__name__,
+                    )
+                    self._sleep_before_retry(attempt)
+                    continue
+                raise LinodeApiError(self._failure_message("Linode API request failed", attempt)) from exc
 
         if not text:
             return {} if allow_empty else {}
@@ -268,6 +298,53 @@ class LinodeClient:
         if isinstance(parsed, dict):
             return parsed
         raise LinodeApiError("Linode API returned an unexpected response")
+
+    def consume_retry_events(self) -> list[dict[str, Any]]:
+        events = [dict(event) for event in self.retry_events]
+        self.retry_events.clear()
+        return events
+
+    def _retry_attempt_limit(self, retry: bool) -> int:
+        if not retry:
+            return 1
+        return max(1, self.max_retry_attempts)
+
+    @staticmethod
+    def _should_retry_status(status: int, *, attempt: int, attempts: int) -> bool:
+        return status in RETRYABLE_STATUS_CODES and attempt < attempts
+
+    def _sleep_before_retry(self, attempt: int) -> None:
+        if not self.retry_backoff_seconds:
+            return
+        delay = self.retry_backoff_seconds[min(attempt - 1, len(self.retry_backoff_seconds) - 1)]
+        if delay > 0:
+            time.sleep(delay)
+
+    def _record_retry_event(
+        self,
+        *,
+        method: str,
+        operation: str | None,
+        attempt: int,
+        attempts: int,
+        reason: str,
+    ) -> None:
+        self.retry_events.append(
+            {
+                "operation": operation or "linode_api_request",
+                "method": method,
+                "attempt": attempt,
+                "next_attempt": attempt + 1,
+                "max_attempts": attempts,
+                "reason": reason,
+            }
+        )
+
+    @staticmethod
+    def _failure_message(message: str, attempt: int) -> str:
+        if attempt <= 1:
+            return message
+        return f"{message} after {attempt} attempts"
 
     @staticmethod
     def _instance_resource(response: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import call, patch
 from urllib.error import HTTPError
 
 from linode_image_lab.linode_api import LinodeApiError, LinodeClient, LinodePreflightError, LinodeTokenError
@@ -96,7 +96,7 @@ class LinodeClientTests(unittest.TestCase):
         )
 
     def test_provider_preflight_failure_uses_sanitized_message(self) -> None:
-        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, retry_backoff_seconds=())
 
         with patch(
             "linode_image_lab.linode_api.urlopen",
@@ -108,6 +108,96 @@ class LinodeClientTests(unittest.TestCase):
         self.assertEqual(str(raised.exception), "requested image is unavailable")
         self.assertNotIn("private/789", str(raised.exception))
         self.assertNotIn(TOKEN_VALUE, str(raised.exception))
+
+    def test_read_retries_transient_http_failures_with_deterministic_backoff(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            max_retry_attempts=3,
+            retry_backoff_seconds=(1.0, 2.0),
+        )
+        responses: list[FakeHTTPResponse | HTTPError] = [
+            self.http_error(429, "rate limited"),
+            self.http_error(500, "server failed"),
+            FakeHTTPResponse({"data": [{"id": 456, "label": "root"}]}),
+        ]
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            response = responses.pop(0)
+            if isinstance(response, HTTPError):
+                raise response
+            return response
+
+        with (
+            patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen),
+            patch("linode_image_lab.linode_api.time.sleep") as sleep,
+        ):
+            disks = client.list_disks(123)
+
+        self.assertEqual([request.get_method() for request in requests], ["GET", "GET", "GET"])
+        self.assertEqual([request.full_url for request in requests], [f"{API_BASE_URL}/linode/instances/123/disks"] * 3)
+        self.assertEqual(disks, [{"id": 456, "label": "root"}])
+        self.assertEqual(sleep.call_args_list, [call(1.0), call(2.0)])
+        self.assertEqual(
+            client.consume_retry_events(),
+            [
+                {
+                    "operation": "list_disks",
+                    "method": "GET",
+                    "attempt": 1,
+                    "next_attempt": 2,
+                    "max_attempts": 3,
+                    "reason": "status_429",
+                },
+                {
+                    "operation": "list_disks",
+                    "method": "GET",
+                    "attempt": 2,
+                    "next_attempt": 3,
+                    "max_attempts": 3,
+                    "reason": "status_500",
+                },
+            ],
+        )
+
+    def test_delete_instance_retries_transient_network_failure(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            max_retry_attempts=2,
+            retry_backoff_seconds=(),
+        )
+        responses: list[FakeHTTPResponse | OSError] = [OSError("network unavailable"), FakeHTTPResponse({})]
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            response = responses.pop(0)
+            if isinstance(response, OSError):
+                raise response
+            return response
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.delete_instance(123)
+
+        self.assertEqual([request.get_method() for request in requests], ["DELETE", "DELETE"])
+        self.assertEqual([request.full_url for request in requests], [f"{API_BASE_URL}/linode/instances/123"] * 2)
+        self.assertEqual(resource, {"linode_id": 123, "deleted": True})
+        self.assertEqual(
+            client.consume_retry_events(),
+            [
+                {
+                    "operation": "delete_instance",
+                    "method": "DELETE",
+                    "attempt": 1,
+                    "next_attempt": 2,
+                    "max_attempts": 2,
+                    "reason": "OSError",
+                }
+            ],
+        )
 
     def test_create_instance_sends_expected_payload_and_maps_response(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
@@ -162,6 +252,35 @@ class LinodeClientTests(unittest.TestCase):
                 "tags": ["project=linode-image-lab"],
             },
         )
+
+    def test_create_instance_does_not_retry_transient_failure(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            max_retry_attempts=3,
+            retry_backoff_seconds=(),
+        )
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            raise self.http_error(500, "server failed")
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            with self.assertRaises(LinodeApiError) as raised:
+                client.create_instance(
+                    region="us-east",
+                    source_image="linode/debian12",
+                    instance_type="g6-nanode-1",
+                    label="lil-run-source",
+                    tags=["project=linode-image-lab"],
+                    root_password="generated-" + "root-pass",
+                )
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].get_method(), "POST")
+        self.assertEqual(str(raised.exception), "Linode API request failed with status 500")
+        self.assertEqual(client.consume_retry_events(), [])
 
     def test_capture_image_sends_expected_payload_and_maps_response(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
@@ -363,7 +482,7 @@ class LinodeClientTests(unittest.TestCase):
                         client.preflight()
 
     def test_non_auth_failure_maps_to_api_error_without_token_value(self) -> None:
-        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, retry_backoff_seconds=())
 
         with patch(
             "linode_image_lab.linode_api.urlopen",
@@ -374,17 +493,17 @@ class LinodeClientTests(unittest.TestCase):
 
         self.assertNotIsInstance(raised.exception, LinodeTokenError)
         self.assertNotIn(TOKEN_VALUE, str(raised.exception))
-        self.assertEqual(str(raised.exception), "Linode API request failed with status 500")
+        self.assertEqual(str(raised.exception), "Linode API request failed with status 500 after 3 attempts")
 
     def test_network_failure_maps_to_api_error_without_token_value(self) -> None:
-        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, retry_backoff_seconds=())
 
         with patch("linode_image_lab.linode_api.urlopen", side_effect=OSError("network unavailable")):
             with self.assertRaises(LinodeApiError) as raised:
                 client.preflight()
 
         self.assertNotIn(TOKEN_VALUE, str(raised.exception))
-        self.assertEqual(str(raised.exception), "Linode API request failed")
+        self.assertEqual(str(raised.exception), "Linode API request failed after 3 attempts")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add bounded, deterministic retries for safe Linode API reads, polling reads, managed Linode discovery, and cleanup delete attempts.
- Keep create-instance, image-create, shutdown, and other mutation requests single-attempt to avoid duplicate resources or unsafe repeated state transitions.
- Attach public-safe retry event summaries to manifest steps and document the retry boundary.

## Validation

- `make check`
- `make security-check`

Closes #18