### PR TITLE
Add config validation defaults report

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,20 @@ defaults. Config values fill omitted CLI flags; explicit CLI flags always win.
 ```sh
 linode-image-lab --config examples/config/capture-deploy-smoke.toml capture-deploy
 linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
+linode-image-lab config validate --config examples/config/capture-deploy-smoke.toml --command capture-deploy
 ```
 
 Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
 `[deploy]`, `[capture-deploy]`, and `[cleanup]` tables. Supported values are
 `region` or `regions`, `ttl`, `source_image`, `image_id`, and `type`, depending
 on the command.
+
+`config validate` parses the TOML file, applies the same safety checks as
+command execution, and emits a non-mutating JSON report with `precedence`,
+`effective_defaults`, and `sources`. Precedence is explicit CLI values first,
+then the selected command table, then `[defaults]`. You can pass supported CLI
+default flags such as `--region`, `--ttl`, `--source-image`, `--image-id`, or
+`--type` to preview how they override the config for the selected command.
 
 Config is only for execution defaults. It cannot contain `LINODE_TOKEN`, token
 values, passwords, SSH keys, cloud-init data, `execute`, `discover`,

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -143,6 +143,10 @@ LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli \
 Config defaults can replace omitted `--region`, `--source-image`,
 `--image-id`, `--type`, and `--ttl` values. They do not replace `--execute`,
 preservation flags, run ids, or environment-based token injection.
+Use `linode-image-lab config validate --config PATH --command COMMAND` to
+validate a config file and inspect the effective defaults before a smoke run.
+The report is non-mutating, does not read `LINODE_TOKEN`, and labels precedence
+as CLI values, then the selected command table, then `[defaults]`.
 
 ## Cleanup
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -73,6 +73,13 @@ defaults in `[defaults]`, `[capture]`, `[deploy]`, `[capture-deploy]`, and
 command-specific config takes precedence over `[defaults]`, and existing
 generated defaults remain last.
 
+`config validate --config PATH --command COMMAND` provides the non-mutating
+inspection path for config files. It validates the TOML schema and safety rules,
+then emits redacted JSON containing the selected command's `precedence`,
+`effective_defaults`, and `sources`. Supported CLI default flags passed to
+`config validate` are included only for precedence inspection; the command does
+not execute workflows, call Linode, or read `LINODE_TOKEN`.
+
 Supported config values are intentionally narrow:
 
 - `region` or `regions`,

--- a/docs/security.md
+++ b/docs/security.md
@@ -12,6 +12,8 @@ non-mutating; capture and deploy execution require explicit opt-in.
 - Plain `cleanup` does not read token values or call Linode.
 - Config files cannot provide `LINODE_TOKEN` or any token value. They only fill
   non-secret execution defaults after explicit `--config PATH`.
+- `config validate` validates and reports effective defaults without reading
+  token values, calling Linode, or mutating resources.
 - Redaction utilities sanitize sensitive keys and token-like text before output.
 - Normal stdout and stderr must not print tokens, authorization headers, root
   passwords, SSH keys, cloud-init secrets, or provider resource identifiers.
@@ -30,6 +32,10 @@ keys, root passwords, cloud-init data, or user-data.
 Config loading and validation happen before token lookup. Execute mode and
 `cleanup --discover` still require `LINODE_TOKEN` from the environment or
 approved environment injection.
+
+The `config validate` report uses the same config safety checks and redacted
+serialization as other CLI output. It shows precedence as CLI values, then the
+selected command table, then `[defaults]`.
 
 ## Execute Permissions
 

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -9,9 +9,15 @@ from typing import Any
 from .cleanup import CleanupError, cleanup_plan
 from .capture import CaptureError, capture_plan
 from .capture_deploy import CaptureDeployError, capture_deploy_plan
-from .config import ConfigError, command_defaults, load_config
+from .config import (
+    COMMAND_DEFAULT_FIELDS,
+    ConfigError,
+    command_defaults,
+    effective_command_defaults,
+    load_config,
+)
 from .deploy import DeployError, deploy_plan
-from .manifest import create_manifest, serialize_manifest
+from .manifest import PROJECT, create_manifest, serialize_manifest
 from .regions import parse_regions
 
 
@@ -38,6 +44,37 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="linode-image-lab")
     add_config_arg(parser, dest="global_config")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    config = subparsers.add_parser("config", help="Validate and inspect config defaults.")
+    config_subparsers = config.add_subparsers(dest="config_action", required=True)
+    config_validate = config_subparsers.add_parser(
+        "validate",
+        help="Validate a config file and show effective command defaults.",
+    )
+    add_config_arg(config_validate, dest="command_config")
+    config_validate.add_argument(
+        "--command",
+        dest="target_command",
+        choices=tuple(COMMAND_DEFAULT_FIELDS),
+        required=True,
+        help="Command whose effective defaults should be resolved.",
+    )
+    config_validate.add_argument(
+        "--region",
+        action="append",
+        help="Optional CLI region override to include in effective-defaults resolution.",
+    )
+    config_validate.add_argument("--ttl", help="Optional CLI TTL override to include in resolution.")
+    config_validate.add_argument(
+        "--source-image",
+        help="Optional CLI source image override to include in resolution.",
+    )
+    config_validate.add_argument("--image-id", help="Optional CLI image id override to include in resolution.")
+    config_validate.add_argument(
+        "--type",
+        dest="instance_type",
+        help="Optional CLI Linode type override to include in resolution.",
+    )
 
     plan = subparsers.add_parser("plan", help="Emit a dry-run manifest preview.")
     add_config_arg(plan, dest="command_config")
@@ -127,6 +164,63 @@ def resolve_config_defaults(args: argparse.Namespace) -> None:
             args.instance_type = defaults["type"]
 
 
+def config_validate_manifest(args: argparse.Namespace) -> dict[str, Any]:
+    path = config_path(args)
+    if path is None:
+        raise ValueError("config validate requires --config PATH")
+
+    config = load_config(path)
+    target_command = args.target_command
+    cli_defaults = config_validation_cli_defaults(args)
+    resolution = effective_command_defaults(config, target_command, cli_defaults=cli_defaults)
+
+    return {
+        "schema_version": 1,
+        "project": PROJECT,
+        "command": "config",
+        "action": "validate",
+        "target_command": target_command,
+        "status": "valid",
+        "valid": True,
+        "dry_run": True,
+        "safety": {
+            "mutates": False,
+            "auth_lookup": "not_attempted",
+        },
+        **resolution,
+    }
+
+
+def config_validation_cli_defaults(args: argparse.Namespace) -> dict[str, Any]:
+    target_command = args.target_command
+    allowed_fields = set(COMMAND_DEFAULT_FIELDS[target_command])
+    values: dict[str, Any] = {}
+
+    candidate_values = {
+        "regions": args.region,
+        "ttl": args.ttl,
+        "source_image": args.source_image,
+        "image_id": args.image_id,
+        "type": args.instance_type,
+    }
+    option_names = {
+        "regions": "--region",
+        "ttl": "--ttl",
+        "source_image": "--source-image",
+        "image_id": "--image-id",
+        "type": "--type",
+    }
+
+    for field, value in candidate_values.items():
+        if value is None:
+            continue
+        if field not in allowed_fields:
+            raise ValueError(f"{option_names[field]} is not supported for {target_command} config defaults")
+        values[field] = value
+
+    return values
+
+
 def config_path(args: argparse.Namespace) -> str | None:
     global_config = getattr(args, "global_config", None)
     command_config = getattr(args, "command_config", None)
@@ -204,8 +298,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
-        resolve_config_defaults(args)
-        manifest = command_manifest(args)
+        if args.command == "config":
+            manifest = config_validate_manifest(args)
+        else:
+            resolve_config_defaults(args)
+            manifest = command_manifest(args)
     except CaptureError as exc:
         if exc.manifest is not None:
             sys.stdout.write(serialize_manifest(exc.manifest))

--- a/src/linode_image_lab/config.py
+++ b/src/linode_image_lab/config.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any
 import tomllib
 
+from .regions import parse_regions
+
 
 class ConfigError(ValueError):
     """Raised when config cannot safely provide execution defaults."""
@@ -29,6 +31,20 @@ TABLE_FIELDS = {
     "cleanup": {"ttl"},
 }
 COMMAND_TABLES = {"capture", "deploy", "capture-deploy", "cleanup"}
+COMMAND_DEFAULT_FIELDS = {
+    "plan": ("regions", "ttl"),
+    "capture": ("regions", "ttl", "source_image", "type"),
+    "deploy": ("regions", "ttl", "image_id", "type"),
+    "capture-deploy": ("regions", "ttl", "source_image", "type"),
+    "cleanup": ("ttl",),
+}
+CLI_SOURCE_LABELS = {
+    "regions": "cli --region",
+    "ttl": "cli --ttl",
+    "source_image": "cli --source-image",
+    "image_id": "cli --image-id",
+    "type": "cli --type",
+}
 PROHIBITED_KEYS = {
     "discover",
     "execute",
@@ -141,3 +157,86 @@ def command_defaults(config: dict[str, Any], command: str) -> dict[str, Any]:
     if command in COMMAND_TABLES:
         values.update(config.get(command, {}))
     return values
+
+
+def effective_command_defaults(
+    config: dict[str, Any],
+    command: str,
+    *,
+    cli_defaults: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return safe, source-labeled defaults for a command.
+
+    The result is suitable for non-mutating config inspection. Values are
+    resolved with the same precedence used by command execution:
+    CLI-provided values, then command tables, then [defaults].
+    """
+    if command not in COMMAND_DEFAULT_FIELDS:
+        raise ConfigError(f"unsupported command for config validation: {command}")
+
+    cli_values = cli_defaults or {}
+    effective_defaults: dict[str, Any] = {}
+    sources: list[dict[str, str]] = []
+
+    for field in COMMAND_DEFAULT_FIELDS[command]:
+        resolved = resolve_default_field(config, command, field, cli_values)
+        if resolved is None:
+            continue
+        value, source = resolved
+        effective_defaults[field] = value
+        sources.append({"field": field, "source": source})
+
+    return {
+        "precedence": precedence_labels(command),
+        "effective_defaults": effective_defaults,
+        "sources": sources,
+    }
+
+
+def precedence_labels(command: str) -> list[str]:
+    labels = ["cli"]
+    if command in COMMAND_TABLES:
+        labels.append(f"[{command}]")
+    labels.append("[defaults]")
+    return labels
+
+
+def resolve_default_field(
+    config: dict[str, Any],
+    command: str,
+    field: str,
+    cli_values: dict[str, Any],
+) -> tuple[Any, str] | None:
+    if field in cli_values:
+        return normalize_default_value(field, cli_values[field]), CLI_SOURCE_LABELS[field]
+
+    command_values = config.get(command, {}) if command in COMMAND_TABLES else {}
+    resolved = resolve_table_field(command_values, field, f"[{command}]")
+    if resolved is not None:
+        return resolved
+
+    return resolve_table_field(config.get("defaults", {}), field, "[defaults]")
+
+
+def resolve_table_field(table: dict[str, Any], field: str, label: str) -> tuple[Any, str] | None:
+    if field == "regions":
+        if "regions" in table:
+            return normalize_default_value(field, table["regions"]), f"{label}.regions"
+        if "region" in table:
+            return normalize_default_value(field, [table["region"]]), f"{label}.region"
+        return None
+
+    if field in table:
+        return table[field], f"{label}.{field}"
+    return None
+
+
+def normalize_default_value(field: str, value: Any) -> Any:
+    if field == "regions":
+        regions = parse_regions(value)
+        if not regions:
+            raise ConfigError(
+                "config validate requires at least one non-empty --region when --region is provided"
+            )
+        return regions
+    return value

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -217,6 +217,138 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["regions"], ["us-west"])
         self.assertEqual(payload["ttl"], "2031-01-01T00:00:00Z")
 
+    def test_config_validate_shows_effective_defaults_and_precedence(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            ttl = "2030-01-01T00:00:00Z"
+
+            [capture]
+            regions = ["us-west"]
+            ttl = "2031-01-01T00:00:00Z"
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(
+                [
+                    "config",
+                    "validate",
+                    "--config",
+                    config_path,
+                    "--command",
+                    "capture",
+                    "--region",
+                    "eu-central",
+                ]
+            )
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertTrue(payload["valid"])
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["safety"], {"auth_lookup": "not_attempted", "mutates": False})
+        self.assertEqual(payload["precedence"], ["cli", "[capture]", "[defaults]"])
+        self.assertEqual(
+            payload["effective_defaults"],
+            {
+                "regions": ["eu-central"],
+                "source_image": "linode/alpine3.23",
+                "ttl": "2031-01-01T00:00:00Z",
+                "type": "g6-nanode-1",
+            },
+        )
+        self.assertEqual(
+            payload["sources"],
+            [
+                {"field": "regions", "source": "cli --region"},
+                {"field": "ttl", "source": "[capture].ttl"},
+                {"field": "source_image", "source": "[capture].source_image"},
+                {"field": "type", "source": "[capture].type"},
+            ],
+        )
+
+    def test_config_validate_never_reads_linode_token(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [deploy]
+            region = "us-east"
+            image_id = "private/example-custom-image"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("linode_image_lab.linode_api.LinodeClient.from_env", side_effect=AssertionError("token lookup")),
+            redirect_stdout(output),
+        ):
+            code = main(["config", "validate", "--config", config_path, "--command", "deploy"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["effective_defaults"]["image_id"], "[REDACTED]")
+        self.assertIn({"field": "image_id", "source": "[deploy].image_id"}, payload["sources"])
+
+    def test_config_validate_rejects_invalid_config_without_command_execution(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            LINODE_TOKEN = "not-used"
+            """
+        )
+
+        error = StringIO()
+        with (
+            patch("linode_image_lab.cli.capture_plan", side_effect=AssertionError("command execution")),
+            redirect_stderr(error),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            main(["config", "validate", "--config", config_path, "--command", "capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("must not contain secrets", error.getvalue())
+
+    def test_config_validate_rejects_unsupported_cli_override_for_command(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [cleanup]
+            ttl = "2030-01-01T00:00:00Z"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(
+                [
+                    "config",
+                    "validate",
+                    "--config",
+                    config_path,
+                    "--command",
+                    "cleanup",
+                    "--region",
+                    "us-east",
+                ]
+            )
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--region is not supported for cleanup config defaults", error.getvalue())
+
     def test_unknown_config_key_fails_clearly(self) -> None:
         config_path = self.write_config(
             """


### PR DESCRIPTION
## Summary

- Add `linode-image-lab config validate` for non-mutating config validation and effective-defaults inspection.
- Report resolved defaults with explicit precedence: CLI values, selected command table, then `[defaults]`.
- Keep config safety checks and redacted serialization in the validation path, including redacted custom image ids.

Closes #21

## Validation

- `make check`
- `make security-check`