### PR TITLE
[codex] Add sequential multi-region capture-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ on the command.
 `capture-deploy --execute` accepts multiple regions through repeated
 `--region` flags or `regions = [...]` config. It captures one custom image in
 the first requested region, then deploys that captured image sequentially to
-each requested region. Image replication or copying is not part of this
-behavior. Standalone `capture --execute` and `deploy --execute` remain
+each requested region. Linode custom images are deployable across regions; the
+first deploy in a region may take longer while the provider handles image
+transfer. Standalone `capture --execute` and `deploy --execute` remain
 single-region only.
 
 `config validate` parses the TOML file, applies the same safety checks as
@@ -267,9 +268,10 @@ region.
 Multi-region status is `succeeded` when every requested deploy region succeeds,
 `partial` when some deploy regions fail, and `failed` when capture fails or
 every deploy region fails. A failed deploy region does not block cleanup for
-that region or execution of later deploy regions. Validation checks are objects
-with `name`, `status`, and a symbolic `target`; failed checks include a
-sanitized `failure_reason`.
+that region or execution of later deploy regions. Partial failures indicate
+real provider/API errors, invalid inputs, or transient issues. Validation checks
+are objects with `name`, `status`, and a symbolic `target`; failed checks
+include a sanitized `failure_reason`.
 
 Cleanup status values are literal: `deleted` means a temporary Linode was
 deleted, `preserved` means a resource was kept or skipped for safety,

--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
 on the command.
 
 `capture-deploy --execute` accepts multiple regions through repeated
-`--region` flags or `regions = [...]` config. It runs the existing
-single-region capture-deploy workflow sequentially for each region and records
-per-region manifests under `results`. Standalone `capture --execute` and
-`deploy --execute` remain single-region only.
+`--region` flags or `regions = [...]` config. It captures one custom image in
+the first requested region, then deploys that captured image sequentially to
+each requested region. Image replication or copying is not part of this
+behavior. Standalone `capture --execute` and `deploy --execute` remain
+single-region only.
 
 `config validate` parses the TOML file, applies the same safety checks as
 command execution, and emits a non-mutating JSON report with `precedence`,
@@ -258,14 +259,17 @@ Execute manifests use consistent top-level `status`, `steps`, `resources`,
 top-level `resources`, `validation`, and `cleanup` summarize the combined run,
 while nested `capture` and `deploy` blocks show phase-specific details.
 Multi-region `capture-deploy --execute` emits one combined manifest with
-top-level `status`, `regions`, `results`, and `summary`; each `results.<region>`
-value is a normal single-region capture-deploy manifest.
+top-level `status`, `regions`, `capture`, `deploy_results`, and `summary`.
+The nested `capture` value is the single capture manifest, and each
+`deploy_results.<region>` value is the deploy manifest for that requested
+region.
 
-Multi-region status is `succeeded` when every region succeeds, `partial` when
-some regions fail, and `failed` when every region fails. A failed region does
-not block cleanup for that region or execution of later regions. Validation
-checks are objects with `name`, `status`, and a symbolic `target`; failed
-checks include a sanitized `failure_reason`.
+Multi-region status is `succeeded` when every requested deploy region succeeds,
+`partial` when some deploy regions fail, and `failed` when capture fails or
+every deploy region fails. A failed deploy region does not block cleanup for
+that region or execution of later deploy regions. Validation checks are objects
+with `name`, `status`, and a symbolic `target`; failed checks include a
+sanitized `failure_reason`.
 
 Cleanup status values are literal: `deleted` means a temporary Linode was
 deleted, `preserved` means a resource was kept or skipped for safety,

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
 `region` or `regions`, `ttl`, `source_image`, `image_id`, and `type`, depending
 on the command.
 
+`capture-deploy --execute` accepts multiple regions through repeated
+`--region` flags or `regions = [...]` config. It runs the existing
+single-region capture-deploy workflow sequentially for each region and records
+per-region manifests under `results`. Standalone `capture --execute` and
+`deploy --execute` remain single-region only.
+
 `config validate` parses the TOML file, applies the same safety checks as
 command execution, and emits a non-mutating JSON report with `precedence`,
 `effective_defaults`, and `sources`. Precedence is explicit CLI values first,
@@ -248,11 +254,18 @@ Modeled resources use rediscoverable tags:
 ## Manifest Output
 
 Execute manifests use consistent top-level `status`, `steps`, `resources`,
-`validation`, and `cleanup` fields. For `capture-deploy`, top-level `resources`
-`validation`, and `cleanup` summarize the combined run, while nested `capture`
-and `deploy` blocks show phase-specific details. Validation checks are objects
-with `name`, `status`, and a symbolic `target`; failed checks include a
-sanitized `failure_reason`.
+`validation`, and `cleanup` fields. For single-region `capture-deploy`,
+top-level `resources`, `validation`, and `cleanup` summarize the combined run,
+while nested `capture` and `deploy` blocks show phase-specific details.
+Multi-region `capture-deploy --execute` emits one combined manifest with
+top-level `status`, `regions`, `results`, and `summary`; each `results.<region>`
+value is a normal single-region capture-deploy manifest.
+
+Multi-region status is `succeeded` when every region succeeds, `partial` when
+some regions fail, and `failed` when every region fails. A failed region does
+not block cleanup for that region or execution of later regions. Validation
+checks are objects with `name`, `status`, and a symbolic `target`; failed
+checks include a sanitized `failure_reason`.
 
 Cleanup status values are literal: `deleted` means a temporary Linode was
 deleted, `preserved` means a resource was kept or skipped for safety,

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -120,20 +120,25 @@ type, and image availability. This keeps each phase independently safe and
 reusable, so combined manifests may show two `preflight_api_access` and
 `preflight_provider_inputs` steps.
 
-When multiple regions are provided, `capture-deploy --execute` runs the full
-single-region capture-deploy flow once per region, in the order supplied by the
-configuration or CLI. Execution is sequential only; there is no parallelism,
-cross-region dependency graph, scheduler, retry fan-out, or infrastructure
-reconciliation. Each region records its own capture, deploy, validation,
-cleanup, resources, and status under `results.<region>`.
+When multiple regions are provided, `capture-deploy --execute` captures one
+custom image in the first requested region, then deploys that same captured
+image sequentially to each requested region. Execution is sequential only;
+there is no parallelism, cross-region dependency graph, scheduler, retry
+fan-out, infrastructure reconciliation, image replication, or image copying.
+The single capture result is recorded under `capture`, and each deploy attempt
+is recorded under `deploy_results.<region>`.
 
-Multi-region execution continues after a region fails. Cleanup for the failed
-region is attempted before the next region runs, and later regions still get
-their own isolated flow. The top-level manifest reports:
+If capture fails, no deploy regions are attempted and the top-level status is
+`failed`. If capture succeeds, multi-region execution continues after a deploy
+region fails. Cleanup for each temporary deploy Linode is handled by that
+region's deploy run, and later deploy regions still get their own isolated
+flow. After all deploy regions finish, the temporary capture-source Linode is
+cleaned up once and the custom image is preserved as the single deliverable.
+The top-level manifest reports:
 
-- `succeeded` when every region succeeds,
-- `partial` when at least one region succeeds and at least one fails,
-- `failed` when every region fails.
+- `succeeded` when every requested deploy region succeeds,
+- `partial` when at least one deploy region succeeds and at least one fails,
+- `failed` when capture fails or every deploy region fails.
 
 The top-level `summary` lists succeeded and failed regions. If any region
 fails, the CLI still emits the combined manifest and exits non-zero.
@@ -213,9 +218,12 @@ Top-level `resources` and `validation` summarize the whole run. Nested
 `deploy.validation` are phase-specific slices of that same lifecycle.
 
 Multi-region capture-deploy execute manifests expose a top-level `status`,
-`regions`, `results`, and `summary`. Each value in `results` is the existing
-single-region capture-deploy execute manifest for that region, including
-`steps`, `resources`, `validation`, and `cleanup`.
+`regions`, `capture`, `deploy_results`, and `summary`. `capture` is the single
+capture manifest from the first requested region. Each value in
+`deploy_results` is a deploy execute manifest for that requested region,
+including `steps`, `resources`, `validation`, and `cleanup`. The top-level
+multi-region manifest is aggregate-only and does not duplicate nested
+`resources`, `validation`, or `cleanup` fields.
 
 `validation` means provider/API-level checks only: input availability, resource
 state, requested region, required tags, disk presence for capture, and image

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -1,8 +1,9 @@
 # Capture-Deploy Workflow
 
 This document describes the current capture/deploy workflow shape. M2 adds
-single-region capture execution, M3 adds single-region deploy execution, and M4
-adds single-region capture-deploy execution.
+single-region capture execution, M3 adds single-region deploy execution, M4
+adds single-region capture-deploy execution, and M5 adds sequential
+multi-region capture-deploy execution.
 
 ## Capture
 
@@ -94,7 +95,7 @@ dry-run manifest and performs no Linode action.
 
 `capture-deploy --execute` is the only mutating combined command. It requires:
 
-- exactly one `--region`,
+- at least one `--region`,
 - `--source-image`,
 - `--type`,
 - `LINODE_TOKEN`.
@@ -118,6 +119,24 @@ the capture and deploy phases, including read-only provider checks for region,
 type, and image availability. This keeps each phase independently safe and
 reusable, so combined manifests may show two `preflight_api_access` and
 `preflight_provider_inputs` steps.
+
+When multiple regions are provided, `capture-deploy --execute` runs the full
+single-region capture-deploy flow once per region, in the order supplied by the
+configuration or CLI. Execution is sequential only; there is no parallelism,
+cross-region dependency graph, scheduler, retry fan-out, or infrastructure
+reconciliation. Each region records its own capture, deploy, validation,
+cleanup, resources, and status under `results.<region>`.
+
+Multi-region execution continues after a region fails. Cleanup for the failed
+region is attempted before the next region runs, and later regions still get
+their own isolated flow. The top-level manifest reports:
+
+- `succeeded` when every region succeeds,
+- `partial` when at least one region succeeds and at least one fails,
+- `failed` when every region fails.
+
+The top-level `summary` lists succeeded and failed regions. If any region
+fails, the CLI still emits the combined manifest and exits non-zero.
 
 Live smoke command shape:
 
@@ -187,11 +206,16 @@ tags did not match, with a `reason` such as `requested`, `tag_mismatch`, or
 ## Manifest Structure
 
 Single-command execute manifests expose top-level `status`, `steps`,
-`resources`, `validation`, and `cleanup`. Capture-deploy keeps the same
-top-level fields and also nests `capture` and `deploy` sections. Top-level
-`resources` and `validation` summarize the whole run. Nested
+`resources`, `validation`, and `cleanup`. Single-region capture-deploy keeps
+the same top-level fields and also nests `capture` and `deploy` sections.
+Top-level `resources` and `validation` summarize the whole run. Nested
 `capture.resources`, `deploy.resources`, `capture.validation`, and
 `deploy.validation` are phase-specific slices of that same lifecycle.
+
+Multi-region capture-deploy execute manifests expose a top-level `status`,
+`regions`, `results`, and `summary`. Each value in `results` is the existing
+single-region capture-deploy execute manifest for that region, including
+`steps`, `resources`, `validation`, and `cleanup`.
 
 `validation` means provider/API-level checks only: input availability, resource
 state, requested region, required tags, disk presence for capture, and image

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -124,9 +124,10 @@ When multiple regions are provided, `capture-deploy --execute` captures one
 custom image in the first requested region, then deploys that same captured
 image sequentially to each requested region. Execution is sequential only;
 there is no parallelism, cross-region dependency graph, scheduler, retry
-fan-out, infrastructure reconciliation, image replication, or image copying.
-The single capture result is recorded under `capture`, and each deploy attempt
-is recorded under `deploy_results.<region>`.
+fan-out, or infrastructure reconciliation. Linode custom images are deployable
+across regions; the first deploy in a region may take longer while the provider
+handles image transfer. The single capture result is recorded under `capture`,
+and each deploy attempt is recorded under `deploy_results.<region>`.
 
 If capture fails, no deploy regions are attempted and the top-level status is
 `failed`. If capture succeeds, multi-region execution continues after a deploy
@@ -140,8 +141,9 @@ The top-level manifest reports:
 - `partial` when at least one deploy region succeeds and at least one fails,
 - `failed` when capture fails or every deploy region fails.
 
-The top-level `summary` lists succeeded and failed regions. If any region
-fails, the CLI still emits the combined manifest and exits non-zero.
+The top-level `summary` lists succeeded and failed regions. Deploy failures
+represent real provider/API errors, invalid inputs, or transient issues. If any
+region fails, the CLI still emits the combined manifest and exits non-zero.
 
 Live smoke command shape:
 

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -42,6 +42,7 @@ class CaptureOptions:
     mode: str = "capture"
     component: str = "capture"
     defer_cleanup: bool = False
+    label_suffix: str | None = None
 
 
 def capture_plan(
@@ -126,8 +127,8 @@ def execute_capture(
         region = options.regions[0]
         source_image = required_text(options.source_image)
         instance_type = required_text(options.instance_type)
-        source_label = f"lil-{safe_label_suffix(manifest['run_id'])}-source"
-        image_label = options.image_label or f"lil-{safe_label_suffix(manifest['run_id'])}-image"
+        source_label = resource_label(manifest["run_id"], "source", suffix=options.label_suffix)
+        image_label = options.image_label or resource_label(manifest["run_id"], "image", suffix=options.label_suffix)
 
         append_step(manifest, "preflight_provider_inputs", mutates=False, status="running")
         run_client.preflight_region(region)
@@ -430,6 +431,14 @@ def required_int(value: object) -> int:
 def safe_label_suffix(value: str) -> str:
     normalized = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
     return (normalized or "run")[:32]
+
+
+def resource_label(run_id: str, resource: str, *, suffix: str | None = None) -> str:
+    parts = ["lil", safe_label_suffix(run_id)]
+    if suffix:
+        parts.append(safe_label_suffix(suffix))
+    parts.append(resource)
+    return "-".join(parts)
 
 
 def safe_error_message(exc: Exception) -> str:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -89,6 +89,78 @@ def execute_capture_deploy(
     client: LinodeClientProtocol | None = None,
 ) -> dict[str, Any]:
     validate_execute_options(options)
+    if len(options.regions) > 1:
+        return execute_multi_region_capture_deploy(options, client=client)
+    return execute_single_region_capture_deploy(options, client=client)
+
+
+def execute_multi_region_capture_deploy(
+    options: CaptureDeployOptions,
+    *,
+    client: LinodeClientProtocol | None = None,
+) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="capture-deploy",
+        mode="capture-deploy",
+        component="capture",
+        regions=options.regions,
+        run_id=options.run_id,
+        ttl=options.ttl,
+        dry_run=False,
+        status="running",
+    )
+    apply_capture_deploy_shape(manifest, mutates=True)
+    manifest["execution_mode"] = "execute"
+    manifest["results"] = {}
+    manifest["summary"] = {"succeeded": [], "failed": []}
+
+    run_client = client or LinodeClient.from_env(command="capture-deploy")
+    for region in options.regions:
+        region_manifest: dict[str, Any]
+        try:
+            region_manifest = execute_single_region_capture_deploy(
+                CaptureDeployOptions(
+                    regions=[region],
+                    run_id=manifest["run_id"],
+                    ttl=manifest["ttl"],
+                    execute=True,
+                    source_image=options.source_image,
+                    instance_type=options.instance_type,
+                    preserve_instance=options.preserve_instance,
+                ),
+                client=run_client,
+                label_suffix=region,
+            )
+        except CaptureDeployError as exc:
+            region_manifest = exc.manifest or failed_region_manifest(
+                region=region,
+                run_id=manifest["run_id"],
+                ttl=manifest["ttl"],
+                exc=exc,
+            )
+
+        manifest["results"][region] = region_manifest
+        if region_manifest.get("status") == "succeeded":
+            manifest["summary"]["succeeded"].append(region)
+        else:
+            manifest["summary"]["failed"].append(region)
+
+    manifest["status"] = aggregate_status(
+        succeeded=manifest["summary"]["succeeded"],
+        failed=manifest["summary"]["failed"],
+    )
+    if manifest["status"] != "succeeded":
+        raise CaptureDeployError("capture-deploy --execute failed for one or more regions", manifest)
+    return manifest
+
+
+def execute_single_region_capture_deploy(
+    options: CaptureDeployOptions,
+    *,
+    client: LinodeClientProtocol | None = None,
+    label_suffix: str | None = None,
+) -> dict[str, Any]:
+    validate_single_region_execute_options(options)
     manifest = create_manifest(
         command="capture-deploy",
         mode="capture-deploy",
@@ -127,6 +199,7 @@ def execute_capture_deploy(
                 mode="capture-deploy",
                 component="capture",
                 defer_cleanup=True,
+                label_suffix=label_suffix,
             ),
             client=run_client,
         )
@@ -149,6 +222,7 @@ def execute_capture_deploy(
                 mode="capture-deploy",
                 component="deploy",
                 defer_cleanup=True,
+                label_suffix=label_suffix,
             ),
             client=run_client,
         )
@@ -193,12 +267,55 @@ def execute_capture_deploy(
 
 
 def validate_execute_options(options: CaptureDeployOptions) -> None:
-    if len(options.regions) != 1:
-        raise CaptureDeployError("capture-deploy --execute requires exactly one non-empty --region")
+    if not options.regions:
+        raise CaptureDeployError("capture-deploy --execute requires at least one non-empty --region")
     if not options.source_image:
         raise CaptureDeployError("capture-deploy --execute requires --source-image for the temporary capture Linode")
     if not options.instance_type:
         raise CaptureDeployError("capture-deploy --execute requires --type for temporary capture and deploy Linodes")
+
+
+def validate_single_region_execute_options(options: CaptureDeployOptions) -> None:
+    if len(options.regions) != 1:
+        raise CaptureDeployError("capture-deploy single-region execution requires exactly one non-empty --region")
+    validate_execute_options(options)
+
+
+def aggregate_status(*, succeeded: list[str], failed: list[str]) -> str:
+    if succeeded and failed:
+        return "partial"
+    if failed:
+        return "failed"
+    return "succeeded"
+
+
+def failed_region_manifest(
+    *,
+    region: str,
+    run_id: str,
+    ttl: str,
+    exc: Exception,
+) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="capture-deploy",
+        mode="capture-deploy",
+        component="capture",
+        regions=[region],
+        run_id=run_id,
+        ttl=ttl,
+        dry_run=False,
+        status="failed",
+    )
+    apply_capture_deploy_shape(manifest, mutates=True)
+    manifest["execution_mode"] = "execute"
+    manifest["steps"] = []
+    manifest["resources"] = []
+    manifest["capture"] = {}
+    manifest["deploy"] = {}
+    manifest["validation"] = {"status": "not_started", "checks": []}
+    manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+    manifest["errors"] = [safe_error_message(exc)]
+    return manifest
 
 
 def apply_capture_deploy_shape(manifest: dict[str, Any], *, mutates: bool) -> None:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -99,7 +99,89 @@ def execute_multi_region_capture_deploy(
     *,
     client: LinodeClientProtocol | None = None,
 ) -> dict[str, Any]:
-    manifest = create_manifest(
+    manifest = multi_region_manifest(options)
+    run_client = client or LinodeClient.from_env(command="capture-deploy")
+    capture_region = options.regions[0]
+
+    try:
+        capture_manifest = execute_capture(
+            CaptureOptions(
+                regions=[capture_region],
+                run_id=manifest["run_id"],
+                ttl=manifest["ttl"],
+                execute=True,
+                source_image=required_text(options.source_image),
+                instance_type=required_text(options.instance_type),
+                preserve_source=False,
+                command="capture-deploy",
+                mode="capture-deploy",
+                component="capture",
+                defer_cleanup=True,
+                label_suffix=capture_region,
+            ),
+            client=run_client,
+        )
+    except CaptureError as exc:
+        manifest["capture"] = exc.manifest or failed_capture_manifest(
+            region=capture_region,
+            run_id=manifest["run_id"],
+            ttl=manifest["ttl"],
+            exc=exc,
+        )
+        manifest["status"] = "failed"
+        raise CaptureDeployError("capture-deploy --execute capture failed", manifest) from exc
+
+    manifest["capture"] = capture_manifest
+    image_id = required_text(capture_manifest.get("custom_image", {}).get("image_id"))
+
+    for region in manifest["summary"]["deploy_regions"]:
+        deploy_manifest: dict[str, Any]
+        try:
+            deploy_manifest = execute_deploy(
+                DeployOptions(
+                    regions=[region],
+                    run_id=manifest["run_id"],
+                    ttl=manifest["ttl"],
+                    execute=True,
+                    image_id=image_id,
+                    instance_type=options.instance_type,
+                    preserve_instance=options.preserve_instance,
+                    command="capture-deploy",
+                    mode="capture-deploy",
+                    component="deploy",
+                    defer_cleanup=False,
+                    label_suffix=region,
+                ),
+                client=run_client,
+            )
+        except DeployError as exc:
+            deploy_manifest = exc.manifest or failed_deploy_manifest(
+                region=region,
+                run_id=manifest["run_id"],
+                ttl=manifest["ttl"],
+                image_id=image_id,
+                exc=exc,
+            )
+
+        manifest["deploy_results"][region] = deploy_manifest
+        if deploy_manifest.get("status") == "succeeded":
+            manifest["summary"]["succeeded"].append(region)
+        else:
+            manifest["summary"]["failed"].append(region)
+
+    cleanup_deferred_capture(run_client, capture_manifest)
+    manifest["capture"] = capture_manifest
+    manifest["status"] = aggregate_status(
+        succeeded=manifest["summary"]["succeeded"],
+        failed=manifest["summary"]["failed"],
+    )
+    if manifest["status"] != "succeeded":
+        raise CaptureDeployError("capture-deploy --execute failed for one or more regions", manifest)
+    return manifest
+
+
+def multi_region_manifest(options: CaptureDeployOptions) -> dict[str, Any]:
+    base = create_manifest(
         command="capture-deploy",
         mode="capture-deploy",
         component="capture",
@@ -109,49 +191,26 @@ def execute_multi_region_capture_deploy(
         dry_run=False,
         status="running",
     )
-    apply_capture_deploy_shape(manifest, mutates=True)
-    manifest["execution_mode"] = "execute"
-    manifest["results"] = {}
-    manifest["summary"] = {"succeeded": [], "failed": []}
-
-    run_client = client or LinodeClient.from_env(command="capture-deploy")
-    for region in options.regions:
-        region_manifest: dict[str, Any]
-        try:
-            region_manifest = execute_single_region_capture_deploy(
-                CaptureDeployOptions(
-                    regions=[region],
-                    run_id=manifest["run_id"],
-                    ttl=manifest["ttl"],
-                    execute=True,
-                    source_image=options.source_image,
-                    instance_type=options.instance_type,
-                    preserve_instance=options.preserve_instance,
-                ),
-                client=run_client,
-                label_suffix=region,
-            )
-        except CaptureDeployError as exc:
-            region_manifest = exc.manifest or failed_region_manifest(
-                region=region,
-                run_id=manifest["run_id"],
-                ttl=manifest["ttl"],
-                exc=exc,
-            )
-
-        manifest["results"][region] = region_manifest
-        if region_manifest.get("status") == "succeeded":
-            manifest["summary"]["succeeded"].append(region)
-        else:
-            manifest["summary"]["failed"].append(region)
-
-    manifest["status"] = aggregate_status(
-        succeeded=manifest["summary"]["succeeded"],
-        failed=manifest["summary"]["failed"],
-    )
-    if manifest["status"] != "succeeded":
-        raise CaptureDeployError("capture-deploy --execute failed for one or more regions", manifest)
-    return manifest
+    return {
+        "schema_version": base["schema_version"],
+        "project": base["project"],
+        "command": base["command"],
+        "mode": base["mode"],
+        "regions": base["regions"],
+        "run_id": base["run_id"],
+        "ttl": base["ttl"],
+        "dry_run": base["dry_run"],
+        "execution_mode": "execute",
+        "status": base["status"],
+        "capture": {},
+        "deploy_results": {},
+        "summary": {
+            "capture_region": options.regions[0],
+            "deploy_regions": list(options.regions),
+            "succeeded": [],
+            "failed": [],
+        },
+    }
 
 
 def execute_single_region_capture_deploy(
@@ -289,7 +348,37 @@ def aggregate_status(*, succeeded: list[str], failed: list[str]) -> str:
     return "succeeded"
 
 
-def failed_region_manifest(
+def cleanup_deferred_capture(client: LinodeClientProtocol, capture_manifest: dict[str, Any]) -> None:
+    if cleanup_status(capture_manifest) != "deferred":
+        return
+    try:
+        cleanup_capture_source(
+            capture_manifest,
+            client,
+            capture_source=capture_manifest["capture_source"],
+            preserve_source=False,
+            required_tags=list(capture_manifest["tags"]),
+        )
+    except Exception:
+        capture_manifest["cleanup"] = {"status": "failed", "deleted": [], "preserved": []}
+        return
+    record_custom_image_deliverable(capture_manifest)
+
+
+def record_custom_image_deliverable(capture_manifest: dict[str, Any]) -> None:
+    custom_image = capture_manifest.get("custom_image")
+    if not custom_image:
+        return
+    cleanup = capture_manifest.setdefault("cleanup", {"status": "not_started", "deleted": [], "preserved": []})
+    preserved = cleanup.setdefault("preserved", [])
+    if any(item.get("reason") == "deliverable" for item in preserved):
+        return
+    deliverable = dict(custom_image)
+    deliverable["reason"] = "deliverable"
+    preserved.append(deliverable)
+
+
+def failed_capture_manifest(
     *,
     region: str,
     run_id: str,
@@ -306,14 +395,46 @@ def failed_region_manifest(
         dry_run=False,
         status="failed",
     )
-    apply_capture_deploy_shape(manifest, mutates=True)
     manifest["execution_mode"] = "execute"
     manifest["steps"] = []
     manifest["resources"] = []
-    manifest["capture"] = {}
-    manifest["deploy"] = {}
+    manifest["capture_source"] = {}
+    manifest["custom_image"] = {}
     manifest["validation"] = {"status": "not_started", "checks": []}
     manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+    for action in manifest["planned_actions"]:
+        action["mutates"] = True
+    manifest["errors"] = [safe_error_message(exc)]
+    return manifest
+
+
+def failed_deploy_manifest(
+    *,
+    region: str,
+    run_id: str,
+    ttl: str,
+    image_id: str,
+    exc: Exception,
+) -> dict[str, Any]:
+    manifest = create_manifest(
+        command="capture-deploy",
+        mode="capture-deploy",
+        component="deploy",
+        regions=[region],
+        run_id=run_id,
+        ttl=ttl,
+        dry_run=False,
+        status="failed",
+    )
+    manifest["execution_mode"] = "execute"
+    manifest["steps"] = []
+    manifest["resources"] = []
+    manifest["deploy_source"] = {"image_id": image_id}
+    manifest["deploy_instance"] = {}
+    manifest["validation"] = {"status": "not_started", "checks": []}
+    manifest["cleanup"] = {"status": "not_started", "deleted": [], "preserved": []}
+    for action in manifest["planned_actions"]:
+        action["mutates"] = True
     manifest["errors"] = [safe_error_message(exc)]
     return manifest
 

--- a/src/linode_image_lab/deploy.py
+++ b/src/linode_image_lab/deploy.py
@@ -39,6 +39,7 @@ class DeployOptions:
     mode: str = "deploy"
     component: str = "deploy"
     defer_cleanup: bool = False
+    label_suffix: str | None = None
 
 
 def deploy_plan(
@@ -120,7 +121,7 @@ def execute_deploy(
         region = options.regions[0]
         image_id = required_text(options.image_id)
         instance_type = required_text(options.instance_type)
-        instance_label = f"lil-{safe_label_suffix(manifest['run_id'])}-deploy"
+        instance_label = resource_label(manifest["run_id"], "deploy", suffix=options.label_suffix)
 
         append_step(manifest, "preflight_provider_inputs", mutates=False, status="running")
         run_client.preflight_region(region)
@@ -347,6 +348,14 @@ def required_int(value: object) -> int:
 def safe_label_suffix(value: str) -> str:
     normalized = re.sub(r"[^a-z0-9-]+", "-", value.lower()).strip("-")
     return (normalized or "run")[:32]
+
+
+def resource_label(run_id: str, resource: str, *, suffix: str | None = None) -> str:
+    parts = ["lil", safe_label_suffix(run_id)]
+    if suffix:
+        parts.append(safe_label_suffix(suffix))
+    parts.append(resource)
+    return "-".join(parts)
 
 
 def safe_error_message(exc: Exception) -> str:

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -34,6 +34,7 @@ class FakeLinodeClient:
         self.capture_count = 0
         self.deploy_count = 0
         self.created_regions: list[str] = []
+        self.deploy_source_images: list[str] = []
         self.instance_regions: dict[int, str] = {}
         self.instance_tags: dict[int, list[str]] = {}
         self.deploy_instance_ids: set[int] = set()
@@ -65,6 +66,7 @@ class FakeLinodeClient:
             linode_id = 321 + self.deploy_count
             self.deploy_count += 1
             self.calls.append("create_deploy_instance")
+            self.deploy_source_images.append(source_image)
             self.deploy_tags = tags
             self.created_regions.append(region)
             self.instance_regions[linode_id] = region
@@ -186,6 +188,12 @@ class RegionDeployPreflightFailureClient(FakeLinodeClient):
             raise LinodePreflightError(f"deploy image unavailable in {self.current_region}")
 
 
+class CaptureValidationFailureClient(FakeLinodeClient):
+    def list_disks(self, linode_id: int) -> list[dict[str, object]]:
+        self.calls.append("list_disks")
+        raise LinodePreflightError("capture source disk unavailable")
+
+
 class CaptureDeployExecutionTests(unittest.TestCase):
     def test_dry_run_does_not_read_token_or_call_execution(self) -> None:
         with (
@@ -259,17 +267,29 @@ class CaptureDeployExecutionTests(unittest.TestCase):
 
         self.assertEqual(manifest["status"], "succeeded")
         self.assertEqual(manifest["regions"], ["us-east", "us-west"])
-        self.assertEqual(manifest["summary"], {"succeeded": ["us-east", "us-west"], "failed": []})
-        self.assertEqual(set(manifest["results"]), {"us-east", "us-west"})
-        self.assertEqual(manifest["results"]["us-east"]["regions"], ["us-east"])
-        self.assertEqual(manifest["results"]["us-west"]["regions"], ["us-west"])
-        self.assertEqual(manifest["results"]["us-east"]["status"], "succeeded")
-        self.assertEqual(manifest["results"]["us-west"]["status"], "succeeded")
+        self.assertEqual(
+            manifest["summary"],
+            {
+                "capture_region": "us-east",
+                "deploy_regions": ["us-east", "us-west"],
+                "succeeded": ["us-east", "us-west"],
+                "failed": [],
+            },
+        )
+        self.assertEqual(set(manifest["deploy_results"]), {"us-east", "us-west"})
+        self.assertEqual(manifest["capture"]["regions"], ["us-east"])
+        self.assertEqual(manifest["deploy_results"]["us-east"]["regions"], ["us-east"])
+        self.assertEqual(manifest["deploy_results"]["us-west"]["regions"], ["us-west"])
+        self.assertEqual(manifest["deploy_results"]["us-east"]["deploy_source"]["image_id"], "private/789")
+        self.assertEqual(manifest["deploy_results"]["us-west"]["deploy_source"]["image_id"], "private/789")
+        self.assertNotIn("resources", manifest)
+        self.assertNotIn("cleanup", manifest)
+        self.assertNotIn("validation", manifest)
 
-    def test_execute_multi_region_runs_sequential_flow_per_region(self) -> None:
+    def test_execute_multi_region_captures_once_then_deploys_to_each_region(self) -> None:
         client = FakeLinodeClient()
 
-        capture_deploy_plan(
+        manifest = capture_deploy_plan(
             regions=["us-east", "us-west"],
             run_id="run-test",
             ttl="2030-01-01T00:00:00Z",
@@ -279,11 +299,15 @@ class CaptureDeployExecutionTests(unittest.TestCase):
             client=client,
         )
 
-        self.assertEqual(client.created_regions, ["us-east", "us-east", "us-west", "us-west"])
-        self.assertEqual(client.deleted, [123, 321, 124, 322])
+        self.assertEqual(client.calls.count("capture_image"), 1)
+        self.assertEqual(client.deploy_source_images, ["private/789", "private/789"])
+        self.assertEqual(client.created_regions, ["us-east", "us-east", "us-west"])
+        self.assertEqual(client.deleted, [321, 322, 123])
+        self.assertEqual(manifest["capture"]["cleanup"]["deleted"][0]["linode_id"], 123)
+        self.assertEqual(manifest["capture"]["cleanup"]["preserved"][0]["reason"], "deliverable")
 
-    def test_execute_multi_region_partial_success_returns_partial_manifest(self) -> None:
-        client = RegionDeployPreflightFailureClient({"us-east"})
+    def test_execute_multi_region_capture_failure_prevents_deploy_attempts(self) -> None:
+        client = CaptureValidationFailureClient()
 
         with self.assertRaises(CaptureDeployError) as raised:
             capture_deploy_plan(
@@ -299,12 +323,44 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         manifest = raised.exception.manifest
         self.assertIsNotNone(manifest)
         assert manifest is not None
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["capture"]["status"], "failed")
+        self.assertEqual(manifest["deploy_results"], {})
+        self.assertNotIn("create_deploy_instance", client.calls)
+        self.assertEqual(client.deleted, [123])
+
+    def test_execute_multi_region_partial_success_returns_partial_manifest(self) -> None:
+        client = RegionDeployPreflightFailureClient({"us-west"})
+
+        with self.assertRaises(CaptureDeployError) as raised:
+            capture_deploy_plan(
+                regions=["us-east", "us-west", "us-lax"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        manifest = raised.exception.manifest
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
         self.assertEqual(manifest["status"], "partial")
-        self.assertEqual(manifest["summary"], {"succeeded": ["us-west"], "failed": ["us-east"]})
-        self.assertEqual(manifest["results"]["us-east"]["status"], "failed")
-        self.assertEqual(manifest["results"]["us-west"]["status"], "succeeded")
-        self.assertEqual(client.created_regions, ["us-east", "us-west", "us-west"])
-        self.assertEqual(client.deleted, [123, 124, 321])
+        self.assertEqual(
+            manifest["summary"],
+            {
+                "capture_region": "us-east",
+                "deploy_regions": ["us-east", "us-west", "us-lax"],
+                "succeeded": ["us-east", "us-lax"],
+                "failed": ["us-west"],
+            },
+        )
+        self.assertEqual(manifest["deploy_results"]["us-east"]["status"], "succeeded")
+        self.assertEqual(manifest["deploy_results"]["us-west"]["status"], "failed")
+        self.assertEqual(manifest["deploy_results"]["us-lax"]["status"], "succeeded")
+        self.assertEqual(client.created_regions, ["us-east", "us-east", "us-lax"])
+        self.assertEqual(client.deleted, [321, 322, 123])
 
     def test_execute_multi_region_all_fail_records_failed_manifest(self) -> None:
         client = RegionDeployPreflightFailureClient({"us-east", "us-west"})
@@ -324,11 +380,19 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         self.assertIsNotNone(manifest)
         assert manifest is not None
         self.assertEqual(manifest["status"], "failed")
-        self.assertEqual(manifest["summary"], {"succeeded": [], "failed": ["us-east", "us-west"]})
-        self.assertEqual(manifest["results"]["us-east"]["status"], "failed")
-        self.assertEqual(manifest["results"]["us-west"]["status"], "failed")
-        self.assertEqual(client.created_regions, ["us-east", "us-west"])
-        self.assertEqual(client.deleted, [123, 124])
+        self.assertEqual(
+            manifest["summary"],
+            {
+                "capture_region": "us-east",
+                "deploy_regions": ["us-east", "us-west"],
+                "succeeded": [],
+                "failed": ["us-east", "us-west"],
+            },
+        )
+        self.assertEqual(manifest["deploy_results"]["us-east"]["status"], "failed")
+        self.assertEqual(manifest["deploy_results"]["us-west"]["status"], "failed")
+        self.assertEqual(client.created_regions, ["us-east"])
+        self.assertEqual(client.deleted, [123])
 
     def test_execute_with_fake_client_records_capture_deploy_cleanup_order(self) -> None:
         client = FakeLinodeClient()
@@ -490,6 +554,28 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         self.assertEqual(exported["deploy"]["deploy_source"]["image_id"], "[REDACTED]")
         self.assertEqual(exported["deploy"]["deploy_instance"]["linode_id"], "[REDACTED]")
         self.assertEqual(exported["cleanup"]["preserved"][0]["image_id"], "[REDACTED]")
+
+    def test_serialized_multi_region_execute_manifest_redacts_provider_ids(self) -> None:
+        manifest = capture_deploy_plan(
+            regions=["us-east", "us-west"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=FakeLinodeClient(),
+        )
+
+        exported = json.loads(serialize_manifest(manifest))
+
+        self.assertEqual(exported["capture"]["capture_source"]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["capture"]["custom_image"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["capture"]["cleanup"]["deleted"][0]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["capture"]["cleanup"]["preserved"][0]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy_results"]["us-east"]["deploy_source"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy_results"]["us-east"]["deploy_instance"]["linode_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy_results"]["us-west"]["deploy_source"]["image_id"], "[REDACTED]")
+        self.assertEqual(exported["deploy_results"]["us-west"]["deploy_instance"]["linode_id"], "[REDACTED]")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -30,11 +30,19 @@ class FakeLinodeClient:
         self.image_tags: list[str] = []
         self.deleted: list[int] = []
         self.missing_deploy_tags = missing_deploy_tags
+        self.current_region = "us-east"
+        self.capture_count = 0
+        self.deploy_count = 0
+        self.created_regions: list[str] = []
+        self.instance_regions: dict[int, str] = {}
+        self.instance_tags: dict[int, list[str]] = {}
+        self.deploy_instance_ids: set[int] = set()
 
     def preflight(self) -> None:
         self.calls.append("preflight")
 
     def preflight_region(self, region: str) -> None:
+        self.current_region = region
         self.calls.append("preflight_region")
 
     def preflight_instance_type(self, instance_type: str) -> None:
@@ -54,20 +62,31 @@ class FakeLinodeClient:
         root_password: str,
     ) -> dict[str, object]:
         if source_image == "private/789":
+            linode_id = 321 + self.deploy_count
+            self.deploy_count += 1
             self.calls.append("create_deploy_instance")
             self.deploy_tags = tags
+            self.created_regions.append(region)
+            self.instance_regions[linode_id] = region
+            self.instance_tags[linode_id] = [] if self.missing_deploy_tags else tags
+            self.deploy_instance_ids.add(linode_id)
             return {
-                "linode_id": 321,
+                "linode_id": linode_id,
                 "label": label,
                 "region": region,
                 "status": "provisioning",
                 "tags": [] if self.missing_deploy_tags else tags,
             }
 
+        linode_id = 123 + self.capture_count
+        self.capture_count += 1
         self.calls.append("create_capture_source")
         self.capture_tags = tags
+        self.created_regions.append(region)
+        self.instance_regions[linode_id] = region
+        self.instance_tags[linode_id] = tags
         return {
-            "linode_id": 123,
+            "linode_id": linode_id,
             "label": label,
             "region": region,
             "status": "provisioning",
@@ -75,21 +94,21 @@ class FakeLinodeClient:
         }
 
     def wait_instance_ready(self, linode_id: int) -> dict[str, object]:
-        if linode_id == 321:
+        if linode_id in self.deploy_instance_ids:
             self.calls.append("wait_deploy_instance_ready")
             return {
                 "linode_id": linode_id,
-                "region": "us-east",
+                "region": self.instance_regions[linode_id],
                 "status": "running",
-                "tags": [] if self.missing_deploy_tags else self.deploy_tags,
+                "tags": self.instance_tags[linode_id],
             }
 
         self.calls.append("wait_capture_source_ready")
         return {
             "linode_id": linode_id,
-            "region": "us-east",
+            "region": self.instance_regions[linode_id],
             "status": "running",
-            "tags": self.capture_tags,
+            "tags": self.instance_tags[linode_id],
         }
 
     def list_disks(self, linode_id: int) -> list[dict[str, object]]:
@@ -104,9 +123,9 @@ class FakeLinodeClient:
         self.calls.append("wait_capture_source_offline")
         return {
             "linode_id": linode_id,
-            "region": "us-east",
+            "region": self.instance_regions[linode_id],
             "status": "offline",
-            "tags": self.capture_tags,
+            "tags": self.instance_tags[linode_id],
         }
 
     def capture_image(
@@ -136,10 +155,10 @@ class FakeLinodeClient:
         }
 
     def delete_instance(self, linode_id: int) -> dict[str, object]:
-        if linode_id == 123:
-            self.calls.append("delete_capture_source")
-        else:
+        if linode_id in self.deploy_instance_ids:
             self.calls.append("delete_deploy_instance")
+        else:
+            self.calls.append("delete_capture_source")
         self.deleted.append(linode_id)
         return {"linode_id": linode_id, "deleted": True}
 
@@ -154,6 +173,17 @@ class InvalidCapturedImageClient(FakeLinodeClient):
         self.calls.append("preflight_image")
         if image_id == "private/789":
             raise LinodePreflightError("requested image is unavailable")
+
+
+class RegionDeployPreflightFailureClient(FakeLinodeClient):
+    def __init__(self, failing_regions: set[str]) -> None:
+        super().__init__()
+        self.failing_regions = failing_regions
+
+    def preflight_image(self, image_id: str) -> None:
+        self.calls.append("preflight_image")
+        if image_id == "private/789" and self.current_region in self.failing_regions:
+            raise LinodePreflightError(f"deploy image unavailable in {self.current_region}")
 
 
 class CaptureDeployExecutionTests(unittest.TestCase):
@@ -198,8 +228,64 @@ class CaptureDeployExecutionTests(unittest.TestCase):
                     instance_type="g6-nanode-1",
                 )
 
-    def test_execute_requires_single_region(self) -> None:
-        with self.assertRaisesRegex(CaptureDeployError, "exactly one non-empty --region"):
+    def test_dry_run_multi_region_remains_non_mutating(self) -> None:
+        manifest = capture_deploy_plan(
+            regions=["us-east", "us-west"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            client=ExplodingClient(),
+        )
+
+        self.assertTrue(manifest["dry_run"])
+        self.assertEqual(manifest["execution_mode"], "dry-run")
+        self.assertEqual(manifest["regions"], ["us-east", "us-west"])
+        self.assertEqual(
+            [(action["action"], action["region"]) for action in manifest["planned_actions"]],
+            [("capture", "us-east"), ("deploy", "us-east"), ("capture", "us-west"), ("deploy", "us-west")],
+        )
+
+    def test_execute_multi_region_all_succeed_records_aggregate_manifest(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_deploy_plan(
+            regions=["us-east", "us-west"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertEqual(manifest["status"], "succeeded")
+        self.assertEqual(manifest["regions"], ["us-east", "us-west"])
+        self.assertEqual(manifest["summary"], {"succeeded": ["us-east", "us-west"], "failed": []})
+        self.assertEqual(set(manifest["results"]), {"us-east", "us-west"})
+        self.assertEqual(manifest["results"]["us-east"]["regions"], ["us-east"])
+        self.assertEqual(manifest["results"]["us-west"]["regions"], ["us-west"])
+        self.assertEqual(manifest["results"]["us-east"]["status"], "succeeded")
+        self.assertEqual(manifest["results"]["us-west"]["status"], "succeeded")
+
+    def test_execute_multi_region_runs_sequential_flow_per_region(self) -> None:
+        client = FakeLinodeClient()
+
+        capture_deploy_plan(
+            regions=["us-east", "us-west"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            client=client,
+        )
+
+        self.assertEqual(client.created_regions, ["us-east", "us-east", "us-west", "us-west"])
+        self.assertEqual(client.deleted, [123, 321, 124, 322])
+
+    def test_execute_multi_region_partial_success_returns_partial_manifest(self) -> None:
+        client = RegionDeployPreflightFailureClient({"us-east"})
+
+        with self.assertRaises(CaptureDeployError) as raised:
             capture_deploy_plan(
                 regions=["us-east", "us-west"],
                 run_id="run-test",
@@ -207,8 +293,42 @@ class CaptureDeployExecutionTests(unittest.TestCase):
                 execute=True,
                 source_image="linode/debian12",
                 instance_type="g6-nanode-1",
-                client=FakeLinodeClient(),
+                client=client,
             )
+
+        manifest = raised.exception.manifest
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["status"], "partial")
+        self.assertEqual(manifest["summary"], {"succeeded": ["us-west"], "failed": ["us-east"]})
+        self.assertEqual(manifest["results"]["us-east"]["status"], "failed")
+        self.assertEqual(manifest["results"]["us-west"]["status"], "succeeded")
+        self.assertEqual(client.created_regions, ["us-east", "us-west", "us-west"])
+        self.assertEqual(client.deleted, [123, 124, 321])
+
+    def test_execute_multi_region_all_fail_records_failed_manifest(self) -> None:
+        client = RegionDeployPreflightFailureClient({"us-east", "us-west"})
+
+        with self.assertRaises(CaptureDeployError) as raised:
+            capture_deploy_plan(
+                regions=["us-east", "us-west"],
+                run_id="run-test",
+                ttl="2030-01-01T00:00:00Z",
+                execute=True,
+                source_image="linode/debian12",
+                instance_type="g6-nanode-1",
+                client=client,
+            )
+
+        manifest = raised.exception.manifest
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["status"], "failed")
+        self.assertEqual(manifest["summary"], {"succeeded": [], "failed": ["us-east", "us-west"]})
+        self.assertEqual(manifest["results"]["us-east"]["status"], "failed")
+        self.assertEqual(manifest["results"]["us-west"]["status"], "failed")
+        self.assertEqual(client.created_regions, ["us-east", "us-west"])
+        self.assertEqual(client.deleted, [123, 124])
 
     def test_execute_with_fake_client_records_capture_deploy_cleanup_order(self) -> None:
         client = FakeLinodeClient()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -530,7 +530,7 @@ class CliTests(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertEqual(payload["regions"], ["us-east", "us-west"])
 
-    def test_multi_region_config_execute_fails_before_token_lookup(self) -> None:
+    def test_multi_region_config_execute_requires_token(self) -> None:
         config_path = self.write_config(
             """
             schema_version = 1
@@ -548,8 +548,7 @@ class CliTests(unittest.TestCase):
                 main(["--config", config_path, "capture-deploy", "--execute"])
 
         self.assertEqual(raised.exception.code, 2)
-        self.assertIn("exactly one non-empty --region", error.getvalue())
-        self.assertNotIn("LINODE_TOKEN", error.getvalue())
+        self.assertIn("LINODE_TOKEN", error.getvalue())
 
     def write_config(self, text: str) -> str:
         directory = tempfile.TemporaryDirectory()


### PR DESCRIPTION
## Summary

- Corrects multi-region `capture-deploy --execute` to capture exactly one custom image in the first requested region.
- Deploys that single captured image sequentially to each requested region, with independent deploy cleanup and failure isolation.
- Preserves the single captured custom image as the deliverable. Linode custom images are deployable across regions; the first deploy in a region may take longer while the provider handles image transfer.
- Keeps dry-run behavior unchanged and leaves standalone `capture --execute` / `deploy --execute` multi-region behavior out of scope.

Closes #20.

## Manifest shape

- Multi-region execute manifests are aggregate-only at the top level.
- Top-level fields include `schema_version`, `project`, `command`, `mode`, `regions`, `run_id`, `ttl`, `dry_run`, `execution_mode`, `status`, `capture`, `deploy_results`, and `summary`.
- `capture` contains the single capture manifest from the first requested region.
- `deploy_results.<region>` contains each per-region deploy manifest.
- `summary` reports `capture_region`, `deploy_regions`, `succeeded`, and `failed`.
- Top-level `resources`, `cleanup`, and `validation` are intentionally not duplicated from nested manifests.

## Validation

- `make check`
- `make security-check`

Tests use fakes only; no live Linode API calls are made.

## Residual risks

- The first deploy in a region may take longer while Linode handles image transfer.
- Partial or failed status can still result from real provider/API errors, invalid inputs, or transient issues.
- No live Linode smoke run was performed for this revision.