### PR TITLE
[codex] Add provider assumption guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,17 @@ Repo-local rules take precedence only for repo-specific behavior.
   validation runs, not infrastructure ownership.
 - Keep cleanup and validation first-class in any execution path.
 
+## Provider Assumptions
+
+- Before changing behavior, docs, tests, or user-facing claims that depend on
+  Linode provider semantics, verify the assumption against public provider
+  documentation.
+- Examples include image region availability, API resource lifecycle, tagging
+  behavior, cleanup safety, rate limits, and error or status semantics.
+- Do not encode guessed provider limitations. If public docs are unclear, state
+  the uncertainty and keep behavior conservative.
+- When relevant, cite or summarize the verified source in PR notes or docs.
+
 ## Public-Safe Boundary
 
 - Treat every file as public.


### PR DESCRIPTION
## Summary

- Add an `AGENTS.md` Provider Assumptions section for Linode-dependent behavior, docs, tests, and user-facing claims.
- Require public provider documentation checks before encoding assumptions about image region availability, API lifecycles, tagging, cleanup safety, rate limits, or error/status semantics.
- Instruct contributors to avoid guessed provider limitations and state uncertainty when public docs are unclear.

## Validation

- `make check` passed.

## Notes

This PR adds repo-local workflow guidance only and does not encode a new concrete provider behavior claim. Future changes that do encode provider semantics should cite or summarize the checked public docs in the PR notes or docs when relevant.