### PR TITLE
[codex] Harden cleanup delete revalidation

### DIFF
--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -113,6 +113,7 @@ def cleanup_plan(
 
         append_step(manifest, "delete_expired_linodes", mutates=bool(manifest["cleanup_candidates"]), status="running")
         deleted: list[dict[str, Any]] = []
+        comparison_time = (now or datetime.now(UTC)).astimezone(UTC)
         for item in assessments:
             if item["action"] != "delete":
                 continue
@@ -121,8 +122,18 @@ def cleanup_plan(
                 item["resource"]["reason"] = "missing_provider_id"
                 manifest["cleanup"]["preserved"].append(item["resource"])
                 continue
+            try:
+                current_resource = run_client.get_instance(linode_id)
+            except Exception:
+                item["resource"]["reason"] = "refetch_failed"
+                manifest["cleanup"]["preserved"].append(item["resource"])
+                continue
+            current_assessment = assess_resource(current_resource, run_id=run_id, now=comparison_time)
+            if current_assessment["action"] != "delete":
+                manifest["cleanup"]["preserved"].append(current_assessment["resource"])
+                continue
             run_client.delete_instance(linode_id)
-            deleted.append(item["resource"])
+            deleted.append(current_assessment["resource"])
         manifest["cleanup"]["deleted"] = deleted
         manifest["cleanup_candidates"] = []
         manifest["cleanup"]["status"] = "completed"

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -73,6 +73,8 @@ class LinodeClientProtocol(Protocol):
 
     def list_managed_linodes(self) -> list[dict[str, Any]]: ...
 
+    def get_instance(self, linode_id: int) -> dict[str, Any]: ...
+
     def delete_instance(self, linode_id: int) -> dict[str, Any]: ...
 
 
@@ -203,6 +205,10 @@ class LinodeClient:
             if not isinstance(pages, int) or page >= pages:
                 return resources
             page += 1
+
+    def get_instance(self, linode_id: int) -> dict[str, Any]:
+        response = self._request("GET", f"/linode/instances/{linode_id}", retry=True, operation="get_instance")
+        return self._instance_resource(response)
 
     def delete_instance(self, linode_id: int) -> dict[str, Any]:
         self._request("DELETE", f"/linode/instances/{linode_id}", retry=True, operation="delete_instance")

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -13,10 +13,19 @@ NOW = datetime(2026, 5, 1, tzinfo=UTC)
 
 
 class FakeCleanupClient:
-    def __init__(self, resources: list[dict[str, object]]) -> None:
+    def __init__(
+        self,
+        resources: list[dict[str, object]],
+        *,
+        refreshed_resources: dict[int, dict[str, object]] | None = None,
+        refetch_failure: bool = False,
+    ) -> None:
         self.resources = resources
+        self.refreshed_resources = refreshed_resources or {}
+        self.refetch_failure = refetch_failure
         self.preflight_count = 0
         self.list_count = 0
+        self.get_count = 0
         self.deleted: list[int] = []
 
     def preflight(self) -> None:
@@ -25,6 +34,17 @@ class FakeCleanupClient:
     def list_managed_linodes(self) -> list[dict[str, object]]:
         self.list_count += 1
         return list(self.resources)
+
+    def get_instance(self, linode_id: int) -> dict[str, object]:
+        self.get_count += 1
+        if self.refetch_failure:
+            raise ValueError("provider response included private details")
+        if linode_id in self.refreshed_resources:
+            return self.refreshed_resources[linode_id]
+        for resource in self.resources:
+            if resource.get("linode_id") == linode_id:
+                return dict(resource)
+        raise ValueError("missing resource")
 
     def delete_instance(self, linode_id: int) -> dict[str, object]:
         self.deleted.append(linode_id)
@@ -94,8 +114,50 @@ class CleanupSelectionTests(unittest.TestCase):
         self.assertFalse(manifest["dry_run"])
         self.assertEqual(manifest["status"], "succeeded")
         self.assertEqual(client.preflight_count, 1)
+        self.assertEqual(client.get_count, 1)
         self.assertEqual(client.deleted, [456])
         self.assertEqual(manifest["cleanup"]["deleted"][0]["reason"], "expired_ttl")
+
+    def test_execute_preserves_candidate_that_becomes_unexpired_before_delete(self) -> None:
+        initial = linode_resource(linode_id=456, ttl="2026-01-01T00:00:00Z")
+        refreshed = linode_resource(linode_id=456, ttl="2030-01-01T00:00:00Z")
+        client = FakeCleanupClient([initial], refreshed_resources={456: refreshed})
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.get_count, 1)
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["deleted"], [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "ttl_not_expired")
+
+    def test_execute_preserves_candidate_that_loses_required_tag_before_delete(self) -> None:
+        initial = linode_resource(linode_id=456)
+        refreshed = linode_resource(linode_id=456)
+        refreshed["tags"] = [
+            "project=linode-image-lab",
+            "run_id=run-test",
+            "mode=capture-deploy",
+            "ttl=2026-01-01T00:00:00Z",
+        ]
+        client = FakeCleanupClient([initial], refreshed_resources={456: refreshed})
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.get_count, 1)
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["deleted"], [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "missing_required_tags")
+
+    def test_execute_preserves_candidate_when_refetch_fails(self) -> None:
+        client = FakeCleanupClient([linode_resource(linode_id=456)], refetch_failure=True)
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.get_count, 1)
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["deleted"], [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "refetch_failed")
+        self.assertNotIn("provider response", json.dumps(manifest["cleanup"]["preserved"]))
 
     def test_unexpired_linode_is_preserved(self) -> None:
         client = FakeCleanupClient([linode_resource(ttl="2030-01-01T00:00:00Z")])

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -364,6 +364,40 @@ class LinodeClientTests(unittest.TestCase):
         self.assertIsNone(getattr(requests[0], "data"))
         self.assertEqual(resource, {"linode_id": 123, "deleted": True})
 
+    def test_get_instance_uses_expected_path_and_maps_response(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+        requests: list[object] = []
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            requests.append(request)
+            return FakeHTTPResponse(
+                {
+                    "id": 123,
+                    "label": "lil-run-capture",
+                    "region": "us-east",
+                    "status": "running",
+                    "tags": ["project=linode-image-lab"],
+                }
+            )
+
+        with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
+            resource = client.get_instance(123)
+
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].get_method(), "GET")
+        self.assertEqual(requests[0].full_url, f"{API_BASE_URL}/linode/instances/123")
+        self.assertIsNone(getattr(requests[0], "data"))
+        self.assertEqual(
+            resource,
+            {
+                "linode_id": 123,
+                "label": "lil-run-capture",
+                "region": "us-east",
+                "status": "running",
+                "tags": ["project=linode-image-lab"],
+            },
+        )
+
     def test_list_managed_linodes_maps_project_tagged_instances(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
         responses = [


### PR DESCRIPTION
## Summary

- Re-fetch each cleanup `--execute` delete candidate with `GET /linode/instances/{linodeId}` immediately before deletion.
- Reassess the current Linode's project, run, mode, component, and TTL tags before calling `DELETE`.
- Preserve candidates with sanitized reasons when re-fetch fails or the current tags/TTL no longer qualify.
- Add focused cleanup and Linode client tests for unchanged delete, changed TTL, missing tag, and re-fetch failure cases.

## External verification

- Akamai Linode API docs list `GET /linode/instances/{linodeId}` as returning a single Linode object: https://techdocs.akamai.com/linode-api/reference/get-linode-instance
- Akamai Linode API docs for updating a Linode describe `tags` as mutable: https://techdocs.akamai.com/linode-api/reference/put-linode-instance

## Validation

- `make check`
- `make security-check`

## Residual risk

- Re-fetch failures intentionally skip deletion, so cleanup can leave expired resources behind when provider state cannot be safely confirmed.