### PR TITLE
[codex] Honor Linode rate limit retry headers

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -50,6 +50,9 @@ preflight reads, polling GET reads, list/read validation calls, managed Linode
 discovery, and cleanup DELETE attempts for already-selected tagged temporary
 Linodes. Retries are bounded, use deterministic backoff without jitter, and
 record public-safe retry event metadata without tokens or provider identifiers.
+For HTTP 429 rate-limit responses, the client honors Linode's documented
+`Retry-After` header when valid, then falls back to `X-RateLimit-Reset` when it
+can be parsed, before using the deterministic backoff.
 
 Create-instance, image-create, shutdown, and other mutation requests remain
 single-attempt so transient failures cannot create duplicate resources or repeat

--- a/docs/security.md
+++ b/docs/security.md
@@ -100,8 +100,10 @@ strings and normal stdout redacts provider identifiers.
 Transient Linode API retries are limited to read-only API calls, polling reads,
 managed Linode discovery, and cleanup DELETE attempts for eligible tagged
 temporary Linodes. Create-instance, image-create, and shutdown requests are not
-retried automatically. Retry errors and metadata use public-safe operation names
-and status categories rather than tokens or provider identifiers.
+retried automatically. HTTP 429 retries honor Linode's documented rate-limit
+headers before falling back to deterministic backoff. Retry errors and metadata
+use public-safe operation names, status categories, and delay sources rather
+than tokens or provider identifiers.
 
 Validation is limited to provider/API responses: input availability, resource
 state, requested region, required tags, disk presence for capture, and image

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from dataclasses import dataclass, field
+from email.utils import parsedate_to_datetime
 from typing import Any, Protocol
 from urllib.error import HTTPError
 from urllib.parse import quote, urlencode
@@ -269,26 +271,32 @@ class LinodeClient:
                 if exc.code in {401, 403}:
                     raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API") from exc
                 if self._should_retry_status(exc.code, attempt=attempt, attempts=attempts):
+                    delay, delay_source = self._retry_delay(exc, attempt)
                     self._record_retry_event(
                         method=method,
                         operation=operation,
                         attempt=attempt,
                         attempts=attempts,
                         reason=f"status_{exc.code}",
+                        retry_delay_seconds=delay,
+                        retry_delay_source=delay_source,
                     )
-                    self._sleep_before_retry(attempt)
+                    self._sleep_before_retry(delay)
                     continue
                 raise LinodeApiError(self._failure_message(f"Linode API request failed with status {exc.code}", attempt)) from exc
             except OSError as exc:
                 if attempt < attempts:
+                    delay, delay_source = self._deterministic_retry_delay(attempt)
                     self._record_retry_event(
                         method=method,
                         operation=operation,
                         attempt=attempt,
                         attempts=attempts,
                         reason=exc.__class__.__name__,
+                        retry_delay_seconds=delay,
+                        retry_delay_source=delay_source,
                     )
-                    self._sleep_before_retry(attempt)
+                    self._sleep_before_retry(delay)
                     continue
                 raise LinodeApiError(self._failure_message("Linode API request failed", attempt)) from exc
 
@@ -313,11 +321,89 @@ class LinodeClient:
     def _should_retry_status(status: int, *, attempt: int, attempts: int) -> bool:
         return status in RETRYABLE_STATUS_CODES and attempt < attempts
 
-    def _sleep_before_retry(self, attempt: int) -> None:
+    def _retry_delay(self, exc: HTTPError, attempt: int) -> tuple[float | None, str | None]:
+        if exc.code == 429:
+            retry_after_delay = self._retry_after_delay(exc)
+            if retry_after_delay is not None:
+                return retry_after_delay, "retry_after"
+
+            rate_limit_reset_delay = self._rate_limit_reset_delay(exc)
+            if rate_limit_reset_delay is not None:
+                return rate_limit_reset_delay, "x_ratelimit_reset"
+
+        return self._deterministic_retry_delay(attempt)
+
+    def _deterministic_retry_delay(self, attempt: int) -> tuple[float | None, str | None]:
         if not self.retry_backoff_seconds:
-            return
+            return None, None
         delay = self.retry_backoff_seconds[min(attempt - 1, len(self.retry_backoff_seconds) - 1)]
-        if delay > 0:
+        return delay, "deterministic_backoff"
+
+    @classmethod
+    def _retry_after_delay(cls, exc: HTTPError) -> float | None:
+        value = cls._response_header(exc, "Retry-After")
+        if value is None:
+            return None
+
+        text = str(value).strip()
+        delay = cls._parse_non_negative_seconds(text)
+        if delay is not None:
+            return delay
+
+        try:
+            retry_at = parsedate_to_datetime(text)
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+        return cls._delay_until(retry_at.timestamp())
+
+    @classmethod
+    def _rate_limit_reset_delay(cls, exc: HTTPError) -> float | None:
+        value = cls._response_header(exc, "X-RateLimit-Reset")
+        if value is None:
+            return None
+
+        try:
+            reset_at = float(str(value).strip())
+        except ValueError:
+            return None
+        return cls._delay_until(reset_at)
+
+    @staticmethod
+    def _delay_until(timestamp: float) -> float | None:
+        if not math.isfinite(timestamp):
+            return None
+        return max(0.0, timestamp - time.time())
+
+    @staticmethod
+    def _parse_non_negative_seconds(value: str) -> float | None:
+        try:
+            delay = float(value)
+        except ValueError:
+            return None
+        if not math.isfinite(delay) or delay < 0:
+            return None
+        return delay
+
+    @staticmethod
+    def _response_header(exc: HTTPError, name: str) -> object | None:
+        headers = exc.headers
+        if not headers:
+            return None
+        get = getattr(headers, "get", None)
+        if callable(get):
+            value = get(name)
+            if value is not None:
+                return value
+        items = getattr(headers, "items", None)
+        if callable(items):
+            for key, value in items():
+                if str(key).lower() == name.lower():
+                    return value
+        return None
+
+    @staticmethod
+    def _sleep_before_retry(delay: float | None) -> None:
+        if delay is not None and delay > 0:
             time.sleep(delay)
 
     def _record_retry_event(
@@ -328,17 +414,22 @@ class LinodeClient:
         attempt: int,
         attempts: int,
         reason: str,
+        retry_delay_seconds: float | None = None,
+        retry_delay_source: str | None = None,
     ) -> None:
-        self.retry_events.append(
-            {
-                "operation": operation or "linode_api_request",
-                "method": method,
-                "attempt": attempt,
-                "next_attempt": attempt + 1,
-                "max_attempts": attempts,
-                "reason": reason,
-            }
-        )
+        event = {
+            "operation": operation or "linode_api_request",
+            "method": method,
+            "attempt": attempt,
+            "next_attempt": attempt + 1,
+            "max_attempts": attempts,
+            "reason": reason,
+        }
+        if retry_delay_seconds is not None:
+            event["retry_delay_seconds"] = retry_delay_seconds
+        if retry_delay_source is not None:
+            event["retry_delay_source"] = retry_delay_source
+        self.retry_events.append(event)
 
     @staticmethod
     def _failure_message(message: str, attempt: int) -> str:

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -38,8 +38,8 @@ def request_payload(request: object) -> dict[str, object]:
 
 
 class LinodeClientTests(unittest.TestCase):
-    def http_error(self, status: int, message: str) -> HTTPError:
-        error = HTTPError(f"{API_BASE_URL}/profile", status, message, {}, None)
+    def http_error(self, status: int, message: str, headers: dict[str, str] | None = None) -> HTTPError:
+        error = HTTPError(f"{API_BASE_URL}/profile", status, message, headers or {}, None)
         self.addCleanup(error.close)
         return error
 
@@ -150,6 +150,8 @@ class LinodeClientTests(unittest.TestCase):
                     "next_attempt": 2,
                     "max_attempts": 3,
                     "reason": "status_429",
+                    "retry_delay_seconds": 1.0,
+                    "retry_delay_source": "deterministic_backoff",
                 },
                 {
                     "operation": "list_disks",
@@ -158,7 +160,98 @@ class LinodeClientTests(unittest.TestCase):
                     "next_attempt": 3,
                     "max_attempts": 3,
                     "reason": "status_500",
+                    "retry_delay_seconds": 2.0,
+                    "retry_delay_source": "deterministic_backoff",
                 },
+            ],
+        )
+
+    def test_rate_limit_retry_honors_retry_after_header(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            max_retry_attempts=2,
+            retry_backoff_seconds=(1.0,),
+        )
+        responses: list[FakeHTTPResponse | HTTPError] = [
+            self.http_error(429, "rate limited", {"Retry-After": "7"}),
+            FakeHTTPResponse({"data": [{"id": 456, "label": "root"}]}),
+        ]
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            response = responses.pop(0)
+            if isinstance(response, HTTPError):
+                raise response
+            return response
+
+        with (
+            patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen),
+            patch("linode_image_lab.linode_api.time.sleep") as sleep,
+        ):
+            disks = client.list_disks(123)
+
+        self.assertEqual(disks, [{"id": 456, "label": "root"}])
+        self.assertEqual(sleep.call_args_list, [call(7.0)])
+        self.assertEqual(
+            client.consume_retry_events(),
+            [
+                {
+                    "operation": "list_disks",
+                    "method": "GET",
+                    "attempt": 1,
+                    "next_attempt": 2,
+                    "max_attempts": 2,
+                    "reason": "status_429",
+                    "retry_delay_seconds": 7.0,
+                    "retry_delay_source": "retry_after",
+                }
+            ],
+        )
+
+    def test_rate_limit_retry_uses_reset_header_when_retry_after_is_invalid(self) -> None:
+        client = LinodeClient(
+            token=TOKEN_VALUE,
+            api_base_url=API_BASE_URL,
+            max_retry_attempts=2,
+            retry_backoff_seconds=(1.0,),
+        )
+        responses: list[FakeHTTPResponse | HTTPError] = [
+            self.http_error(
+                429,
+                "rate limited",
+                {"Retry-After": "soon", "X-RateLimit-Reset": "115"},
+            ),
+            FakeHTTPResponse({"data": [{"id": 456, "label": "root"}]}),
+        ]
+
+        def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
+            response = responses.pop(0)
+            if isinstance(response, HTTPError):
+                raise response
+            return response
+
+        with (
+            patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen),
+            patch("linode_image_lab.linode_api.time.time", return_value=100.0),
+            patch("linode_image_lab.linode_api.time.sleep") as sleep,
+        ):
+            disks = client.list_disks(123)
+
+        self.assertEqual(disks, [{"id": 456, "label": "root"}])
+        self.assertEqual(sleep.call_args_list, [call(15.0)])
+        self.assertEqual(
+            client.consume_retry_events(),
+            [
+                {
+                    "operation": "list_disks",
+                    "method": "GET",
+                    "attempt": 1,
+                    "next_attempt": 2,
+                    "max_attempts": 2,
+                    "reason": "status_429",
+                    "retry_delay_seconds": 15.0,
+                    "retry_delay_source": "x_ratelimit_reset",
+                }
             ],
         )
 


### PR DESCRIPTION
## Summary

- Honor Linode HTTP 429 `Retry-After` delays before deterministic retry backoff.
- Use `X-RateLimit-Reset` as a parseable fallback when `Retry-After` is absent or invalid.
- Record public-safe retry delay/source metadata and document the rate-limit header behavior.

## Provider Docs

Linode API rate-limit documentation describes 429 responses and the `Retry-After` and `X-RateLimit-Reset` response headers: https://techdocs.akamai.com/linode-api/reference/rate-limits

## Validation

- `make check`
- `make security-check`