### PR TITLE
[codex] Tighten provider audit wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,10 @@ Repo-local rules take precedence only for repo-specific behavior.
   `deploy --execute`; default behavior remains non-mutating.
 - M4 permits explicit single-region capture-deploy execution only through
   `capture-deploy --execute`; default behavior remains non-mutating.
-- Do not add multi-region execution or additional real Linode mutation behavior
-  until a later milestone explicitly asks for it.
+- M5 permits explicit sequential multi-region capture-deploy execution only
+  through `capture-deploy --execute`; default behavior remains non-mutating.
+- Do not add additional real Linode mutation behavior until a later milestone
+  explicitly asks for it.
 
 ## Execution Model Boundary
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ on the command.
 `--region` flags or `regions = [...]` config. It captures one custom image in
 the first requested region, then deploys that captured image sequentially to
 each requested region. Linode custom images are deployable across regions; the
-first deploy in a region may take longer while the provider handles image
-transfer. Standalone `capture --execute` and `deploy --execute` remain
+public docs do not specify cross-region deploy latency. Operators should expect
+farther-region deploys may take longer, but the tool does not depend on that
+timing. Standalone `capture --execute` and `deploy --execute` remain
 single-region only.
 
 `config validate` parses the TOML file, applies the same safety checks as
@@ -184,7 +185,8 @@ environment or approved environment injection.
 
 - SSH, cloud-init, service, or application-level validation.
 - Manage long-lived infrastructure.
-- Multi-region orchestration yet.
+- General-purpose multi-region orchestration outside sequential
+  `capture-deploy --execute` validation runs.
 
 ## Commands
 
@@ -252,6 +254,9 @@ Modeled resources use rediscoverable tags:
 - `mode=<capture|deploy|capture-deploy>`
 - `component=<capture|deploy>`
 - `ttl=<timestamp>`
+
+`ttl` is a project-internal cleanup tag used by this tool. Linode does not
+enforce it as a provider-side expiration policy.
 
 ## Manifest Output
 

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -125,9 +125,10 @@ custom image in the first requested region, then deploys that same captured
 image sequentially to each requested region. Execution is sequential only;
 there is no parallelism, cross-region dependency graph, scheduler, retry
 fan-out, or infrastructure reconciliation. Linode custom images are deployable
-across regions; the first deploy in a region may take longer while the provider
-handles image transfer. The single capture result is recorded under `capture`,
-and each deploy attempt is recorded under `deploy_results.<region>`.
+across regions; public docs do not specify cross-region deploy latency.
+Operators should expect farther-region deploys may take longer, but the tool
+does not depend on that timing. The single capture result is recorded under
+`capture`, and each deploy attempt is recorded under `deploy_results.<region>`.
 
 If capture fails, no deploy regions are attempted and the top-level status is
 `failed`. If capture succeeds, multi-region execution continues after a deploy
@@ -186,6 +187,9 @@ required tags are present:
 - `component=<capture|deploy>`
 - `ttl=<timestamp>`
 
+`ttl` is a project-internal cleanup tag used by this tool. Linode does not
+enforce it as a provider-side expiration policy.
+
 Execute-mode cleanup inside capture, deploy, and capture-deploy is narrower
 than standalone cleanup. Capture only attempts to delete the current run's
 temporary capture-source Linode, deploy only attempts to delete the current
@@ -227,9 +231,9 @@ including `steps`, `resources`, `validation`, and `cleanup`. The top-level
 multi-region manifest is aggregate-only and does not duplicate nested
 `resources`, `validation`, or `cleanup` fields.
 
-`validation` means provider/API-level checks only: input availability, resource
-state, requested region, required tags, disk presence for capture, and image
-availability for capture. It does not include SSH, app health, service
+`validation` means provider/API-level checks only: input existence/access,
+image available status, resource state, requested region, required tags, and
+disk presence for capture. It does not include SSH, app health, service
 readiness, or cloud-init completion checks.
 
 Validation checks are structured as stable objects with `name`, `status`, and a

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,24 +9,25 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
 - Create sanitized manifest previews for dry-run planning.
 - Define a stable tag contract for resource rediscovery.
 - Make cleanup selection testable without cloud access.
-- Allow single-region capture, deploy, and capture-deploy execution only after
-  explicit opt-in.
+- Allow capture, deploy, and capture-deploy execution only after explicit
+  opt-in; capture-deploy may fan out sequentially across requested regions.
 
 ## Non-Goals
 
 - No implicit Linode API mutations.
-- No multi-region execution, GitHub Actions mutation, or external scheduler
-  integration.
+- No GitHub Actions mutation, external scheduler integration, or
+  general-purpose multi-region orchestration outside sequential
+  capture-deploy validation runs.
 - No infrastructure ownership or planning model.
 - CI exists to run `make check`.
 
 ## Execution Model Boundary
 
-Future configuration and future multi-region support are execution defaults for
-disposable validation runs. They must not turn the tool into infrastructure
-ownership. Runs remain ephemeral validation workflows with explicit mutation
-entrypoints, provider/API-level validation, tagged temporary resources, and
-cleanup as a first-class outcome.
+Configuration and multi-region support are execution defaults for disposable
+validation runs. They must not turn the tool into infrastructure ownership.
+Runs remain ephemeral validation workflows with explicit mutation entrypoints,
+provider/API-level validation, tagged temporary resources, and cleanup as a
+first-class outcome.
 
 ## Components
 
@@ -104,9 +105,9 @@ Supported config values are intentionally narrow:
 passwords, SSH keys, root passwords, and cloud-init or user-data fields are not
 configurable. Unknown keys and secret-like keys fail before command execution.
 
-Multi-region config is accepted for dry-run manifests. Execute mode still
-requires exactly one effective region and fails before token lookup when config
-or CLI values resolve to multiple regions.
+Multi-region config is accepted for dry-run manifests. Execute mode remains
+single-region for `capture` and `deploy`; `capture-deploy --execute` accepts
+multiple regions and runs one capture followed by sequential deploy attempts.
 
 ## Capture Execution Boundary
 
@@ -117,7 +118,7 @@ a Linode type, and `LINODE_TOKEN`.
 The execute flow is intentionally linear:
 
 1. preflight the token with non-mutating API calls,
-2. preflight the requested region, Linode type, and source image with
+2. preflight the requested region, Linode type, and available source image with
    non-mutating API calls,
 3. create a tagged temporary capture-source Linode,
 4. wait for readiness,
@@ -139,7 +140,7 @@ custom image id via `--image-id`, a Linode type, and `LINODE_TOKEN`.
 The execute flow is intentionally linear:
 
 1. preflight the token with non-mutating API calls,
-2. preflight the requested region, Linode type, and deploy image with
+2. preflight the requested region, Linode type, and available deploy image with
    non-mutating API calls,
 3. create a tagged temporary deploy Linode from the custom image id,
 4. wait for provider/API-level running status,
@@ -152,8 +153,8 @@ validation.
 ## Capture-Deploy Execution Boundary
 
 `capture-deploy` without `--execute` remains non-mutating and does not read
-`LINODE_TOKEN`. `capture-deploy --execute` requires exactly one region, a source
-image, a Linode type, and `LINODE_TOKEN`.
+`LINODE_TOKEN`. `capture-deploy --execute` requires at least one region, a
+source image, a Linode type, and `LINODE_TOKEN`.
 
 The execute flow reuses the capture and deploy internals:
 
@@ -172,6 +173,12 @@ Because capture and deploy remain independently reusable, capture-deploy runs
 each phase's non-mutating API preflight, including provider input checks.
 Seeing two `preflight_api_access` and `preflight_provider_inputs` steps in a
 combined manifest is expected.
+
+With multiple requested regions, capture-deploy captures one custom image in
+the first region and then deploys it sequentially to each requested region.
+Linode custom images are deployable across regions; public docs do not specify
+cross-region deploy latency. Operators should expect farther-region deploys may
+take longer, but the tool does not depend on that timing.
 
 ## Cleanup Semantics
 
@@ -194,6 +201,9 @@ discovery, and deletes only expired Linodes carrying all required managed tags:
 - `mode=...`
 - `component=...`
 - `ttl=...`
+
+`ttl` is a project-internal cleanup tag used by this tool. Linode does not
+enforce it as a provider-side expiration policy.
 
 Standalone cleanup never deletes custom images, untagged resources, or broader
 account resources. Malformed TTL values, future TTL values, missing required

--- a/docs/security.md
+++ b/docs/security.md
@@ -92,10 +92,12 @@ Temporary Linodes are deleted only when all required tags match the current run.
 
 Standalone `cleanup --execute` deletes only expired temporary Linodes with the
 complete managed tag set: `project`, `run_id`, `mode`, `component`, and `ttl`.
-It preserves custom images, untagged resources, resources with missing or
-mismatched tags, resources with malformed or unexpired TTL values, and resources
-outside an optional `--run-id` filter. Preserved entries use sanitized reason
-strings and normal stdout redacts provider identifiers.
+The `ttl` value is a project-internal cleanup tag used by this tool; Linode
+does not enforce it as a provider-side expiration policy. Cleanup preserves
+custom images, untagged resources, resources with missing or mismatched tags,
+resources with malformed or unexpired TTL values, and resources outside an
+optional `--run-id` filter. Preserved entries use sanitized reason strings and
+normal stdout redacts provider identifiers.
 
 Transient Linode API retries are limited to read-only API calls, polling reads,
 managed Linode discovery, and cleanup DELETE attempts for eligible tagged
@@ -103,7 +105,7 @@ temporary Linodes. Create-instance, image-create, and shutdown requests are not
 retried automatically. Retry errors and metadata use public-safe operation names
 and status categories rather than tokens or provider identifiers.
 
-Validation is limited to provider/API responses: input availability, resource
-state, requested region, required tags, disk presence for capture, and image
-availability for capture. It does not perform SSH, cloud-init, service, or
+Validation is limited to provider/API responses: input existence/access, image
+available status, resource state, requested region, required tags, and disk
+presence for capture. It does not perform SSH, cloud-init, service, or
 application readiness checks.

--- a/src/linode_image_lab/linode_api.py
+++ b/src/linode_image_lab/linode_api.py
@@ -117,7 +117,14 @@ class LinodeClient:
 
     def preflight_image(self, image_id: str) -> None:
         escaped = quote(image_id, safe="")
-        self._preflight_resource(f"/images/{escaped}", "requested image is unavailable")
+        try:
+            response = self._request("GET", f"/images/{escaped}", retry=True, operation="preflight_resource")
+        except LinodeTokenError:
+            raise
+        except LinodeApiError as exc:
+            raise LinodePreflightError("requested image is unavailable") from exc
+        if response.get("status") != "available":
+            raise LinodePreflightError("requested image is not available")
 
     def create_instance(
         self,
@@ -266,8 +273,10 @@ class LinodeClient:
                     text = response.read().decode("utf-8")
                 break
             except HTTPError as exc:
-                if exc.code in {401, 403}:
-                    raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API") from exc
+                if exc.code == 401:
+                    raise LinodeTokenError("LINODE_TOKEN is invalid, expired, or rejected by the Linode API") from exc
+                if exc.code == 403:
+                    raise LinodeTokenError("LINODE_TOKEN lacks required Linode permissions or scopes") from exc
                 if self._should_retry_status(exc.code, attempt=attempt, attempts=attempts):
                     self._record_retry_event(
                         method=method,

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -129,7 +129,7 @@ class ExplodingClient:
 class InvalidTokenClient(FakeLinodeClient):
     def preflight(self) -> None:
         self.calls.append("preflight")
-        raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
+        raise LinodeTokenError("LINODE_TOKEN is invalid, expired, or rejected by the Linode API")
 
 
 class InvalidSourceImageClient(FakeLinodeClient):

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -111,7 +111,7 @@ class ExplodingClient:
 class InvalidTokenClient(FakeLinodeClient):
     def preflight(self) -> None:
         self.calls.append("preflight")
-        raise LinodeTokenError("LINODE_TOKEN was rejected by the Linode API")
+        raise LinodeTokenError("LINODE_TOKEN is invalid, expired, or rejected by the Linode API")
 
 
 class InvalidProviderInputClient(FakeLinodeClient):

--- a/tests/unit/test_linode_api.py
+++ b/tests/unit/test_linode_api.py
@@ -78,6 +78,8 @@ class LinodeClientTests(unittest.TestCase):
 
         def fake_urlopen(request: object, timeout: float) -> FakeHTTPResponse:
             requests.append(request)
+            if request.full_url.endswith("/images/linode%2Fdebian12"):
+                return FakeHTTPResponse({"status": "available"})
             return FakeHTTPResponse({})
 
         with patch("linode_image_lab.linode_api.urlopen", side_effect=fake_urlopen):
@@ -106,6 +108,20 @@ class LinodeClientTests(unittest.TestCase):
                 client.preflight_image("private/789")
 
         self.assertEqual(str(raised.exception), "requested image is unavailable")
+        self.assertNotIn("private/789", str(raised.exception))
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
+
+    def test_provider_preflight_image_requires_available_status(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        with patch(
+            "linode_image_lab.linode_api.urlopen",
+            return_value=FakeHTTPResponse({"id": "private/789", "status": "creating"}),
+        ):
+            with self.assertRaises(LinodePreflightError) as raised:
+                client.preflight_image("private/789")
+
+        self.assertEqual(str(raised.exception), "requested image is not available")
         self.assertNotIn("private/789", str(raised.exception))
         self.assertNotIn(TOKEN_VALUE, str(raised.exception))
 
@@ -468,18 +484,31 @@ class LinodeClientTests(unittest.TestCase):
         self.assertEqual(resource["status"], "running")
         self.assertEqual(responses, [])
 
-    def test_auth_failures_map_to_token_error(self) -> None:
+    def test_unauthorized_auth_failure_names_invalid_or_expired_token(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
 
-        for status in (401, 403):
-            with self.subTest(status=status):
-                error = self.http_error(status, "auth failed")
-                with patch(
-                    "linode_image_lab.linode_api.urlopen",
-                    side_effect=error,
-                ):
-                    with self.assertRaises(LinodeTokenError):
-                        client.preflight()
+        with patch(
+            "linode_image_lab.linode_api.urlopen",
+            side_effect=self.http_error(401, "auth failed"),
+        ):
+            with self.assertRaises(LinodeTokenError) as raised:
+                client.preflight()
+
+        self.assertEqual(str(raised.exception), "LINODE_TOKEN is invalid, expired, or rejected by the Linode API")
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
+
+    def test_forbidden_auth_failure_names_missing_permissions_or_scopes(self) -> None:
+        client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL)
+
+        with patch(
+            "linode_image_lab.linode_api.urlopen",
+            side_effect=self.http_error(403, "auth failed"),
+        ):
+            with self.assertRaises(LinodeTokenError) as raised:
+                client.preflight()
+
+        self.assertEqual(str(raised.exception), "LINODE_TOKEN lacks required Linode permissions or scopes")
+        self.assertNotIn(TOKEN_VALUE, str(raised.exception))
 
     def test_non_auth_failure_maps_to_api_error_without_token_value(self) -> None:
         client = LinodeClient(token=TOKEN_VALUE, api_base_url=API_BASE_URL, retry_backoff_seconds=())


### PR DESCRIPTION
## Summary

- Removes unsupported cross-region image transfer mechanism wording and replaces it with deployability plus unspecified latency language.
- Checks image preflight responses for `status == "available"` before treating an image as deploy-ready.
- Splits Linode auth failures into 401 invalid/expired/rejected token messaging and 403 missing permissions/scopes messaging.
- Clarifies TTL as a project-internal cleanup tag and fixes stale multi-region execution wording.

## Public docs checked

- Akamai/Linode Images docs say custom images are deployable across regions, but do not specify cross-region deploy latency: https://techdocs.akamai.com/cloud-computing/docs/images
- Akamai/Linode API docs define 401 as failed authentication from an invalid or expired PAT/OAuth value: https://techdocs.akamai.com/linode-api/reference/401
- Akamai/Linode API docs define 403 as authenticated but lacking operation access or OAuth scope: https://techdocs.akamai.com/linode-api/reference/403

## Validation

- `make check`
- `make security-check`
