### PR TITLE
[codex] Add authoritative source check workflow

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -1,0 +1,13 @@
+name: Authoritative Source Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  authoritative-source-check:
+    uses: ctrl-alt-keith/ai-workflow-playbook/.github/workflows/authoritative-source-check.yml@main
+    with:
+      scan_mode: changed


### PR DESCRIPTION
## Summary

- Add a lightweight pull_request workflow that calls the reusable authoritative source check from ctrl-alt-keith/ai-workflow-playbook pinned to main.
- Keep the workflow advisory through the reusable playbook implementation and limit local permissions to contents: read.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/authoritative-source-check.yml'); puts 'YAML OK'"`
- `make check`
- `make security-check`
- GitHub Actions confirmed `authoritative-source-check / authoritative-source-check` appears on PR #44 and passes.
- GitHub Actions confirmed existing `make check` passes on PR #44.

## Residual Risk

- Optional warning-behavior verification with a deliberately failing/test PR was not run.