### PR TITLE
[codex] Smoke test authoritative source warning

### DIFF
--- a/docs/authoritative-source-check-smoke.md
+++ b/docs/authoritative-source-check-smoke.md
@@ -1,0 +1,4 @@
+# Authoritative Source Check Smoke Test
+
+This temporary documentation note gives the advisory source scanner a harmless
+Markdown-only pull request to evaluate.


### PR DESCRIPTION
## Summary

- Adds a minimal Markdown-only smoke-test note for the advisory scanner.

## Source Check Probe

This PR intentionally includes one non-authoritative source URL to verify warning behavior: https://stackoverflow.com/a/1

## Validation

- `make check`
- Local scanner dry run reported one warning for `stackoverflow.com` and no additional domains.
