### PR TITLE
[codex] Add human-gated smoke target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON ?= python3
+REGION ?= us-sea
 export PYTHONPATH := src
 RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
 RELEASE_TAG = v$(RELEASE_VERSION)
@@ -24,7 +25,7 @@ smoke:
 		exit 1; \
 	fi
 	@echo "WARNING: This will create and delete temporary Linodes"
-	linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
+	linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --region "$(REGION)" --execute
 
 check-gh-env:
 	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export PYTHONPATH := src
 RELEASE_VERSION = $(patsubst v%,%,$(VERSION))
 RELEASE_TAG = v$(RELEASE_VERSION)
 
-.PHONY: check test security-check check-gh-env release-notes release-check release-publish
+.PHONY: check test security-check smoke check-gh-env release-notes release-check release-publish
 
 check: security-check test
 
@@ -12,6 +12,19 @@ test:
 
 security-check:
 	$(PYTHON) -m linode_image_lab.validation .
+
+smoke:
+	@if [ -z "$${LINODE_TOKEN:-}" ]; then \
+		echo "Error: LINODE_TOKEN is required for make smoke." >&2; \
+		exit 1; \
+	fi
+	@if [ "$(SMOKE_EXECUTE)" != "1" ]; then \
+		echo "Error: SMOKE_EXECUTE=1 is required for make smoke." >&2; \
+		echo "This target is manual-only and creates real Linode resources." >&2; \
+		exit 1; \
+	fi
+	@echo "WARNING: This will create and delete temporary Linodes"
+	linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
 
 check-gh-env:
 	@command -v gh >/dev/null 2>&1 || { echo "Error: GitHub CLI (gh) is required but is not installed." >&2; exit 1; }

--- a/README.md
+++ b/README.md
@@ -138,15 +138,21 @@ WARNING: This will create and delete temporary Linodes
 Then it runs the known-good smoke config:
 
 ```sh
-linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
+linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --region us-sea --execute
 ```
 
-Run it only when you are ready to create billable temporary Linodes and preserve
-one custom image deliverable:
+The default smoke region is `us-sea`. Run it only when you are ready to create
+billable temporary Linodes and preserve one custom image deliverable:
 
 ```sh
 export LINODE_TOKEN='<your-linode-api-token>'
 SMOKE_EXECUTE=1 make smoke
+```
+
+Override the region explicitly when needed:
+
+```sh
+SMOKE_EXECUTE=1 REGION=us-lax make smoke
 ```
 
 Expected output is the warning followed by a redacted JSON manifest. A successful

--- a/README.md
+++ b/README.md
@@ -120,6 +120,43 @@ LINODE_TOKEN='op://Private/Linode API Token/credential' op run -- \
     --execute
 ```
 
+## Live Smoke Test
+
+`make smoke` is a manual-only validation target for exercising the full
+`capture-deploy --execute` path against real Linode APIs. It is intentionally
+separate from `make check` and should not be wired into CI, schedules, or other
+automation.
+
+The target requires both `LINODE_TOKEN` and the explicit opt-in variable
+`SMOKE_EXECUTE=1`. Without both gates, it exits before running the mutating
+command. When enabled, it prints this warning:
+
+```text
+WARNING: This will create and delete temporary Linodes
+```
+
+Then it runs the known-good smoke config:
+
+```sh
+linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --execute
+```
+
+Run it only when you are ready to create billable temporary Linodes and preserve
+one custom image deliverable:
+
+```sh
+export LINODE_TOKEN='<your-linode-api-token>'
+SMOKE_EXECUTE=1 make smoke
+```
+
+Expected output is the warning followed by a redacted JSON manifest. A successful
+single-region smoke run reports `status: "succeeded"`, includes nested
+`capture` and `deploy` sections, records deleted temporary capture and deploy
+Linodes in cleanup data, and preserves one custom image as the deliverable.
+Provider or validation failures are reported with public-safe symbolic targets
+and sanitized failure reasons; normal stdout must not expose provider resource
+identifiers.
+
 ## Config Defaults
 
 Pass `--config` before or after the command to load optional TOML execution


### PR DESCRIPTION
## Summary

Closes #22.

Adds a manual-only `make smoke` target that requires both `LINODE_TOKEN` and `SMOKE_EXECUTE=1` before invoking the live `capture-deploy --execute` path with `examples/config/capture-deploy-smoke.toml`.

The smoke target now defaults to `REGION=us-sea` and passes the selected region as a CLI override. Callers can run `REGION=<region> make smoke` to choose a different smoke region while still using the config file for source image, type, and TTL defaults.

Documents the live smoke workflow in the README, including the real-resource warning, default region, override example, expected redacted manifest shape, cleanup behavior for temporary Linodes, and the preserved custom image deliverable.

## Sample usage

```sh
export LINODE_TOKEN='<your-linode-api-token>'
SMOKE_EXECUTE=1 make smoke
```

Override the smoke region:

```sh
SMOKE_EXECUTE=1 REGION=us-lax make smoke
```

The target prints:

```text
WARNING: This will create and delete temporary Linodes
```

Then runs the equivalent of:

```sh
linode-image-lab capture-deploy --config examples/config/capture-deploy-smoke.toml --region us-sea --execute
```

## Validation

- `make smoke` exits before mutation when `LINODE_TOKEN` is missing.
- `LINODE_TOKEN=dummy make smoke` exits before mutation when `SMOKE_EXECUTE=1` is missing.
- `SMOKE_EXECUTE=1 LINODE_TOKEN=dummy make -n smoke` shows `--region "us-sea"` without executing.
- `SMOKE_EXECUTE=1 LINODE_TOKEN=dummy REGION=us-lax make -n smoke` shows `--region "us-lax"` without executing.
- `make check` passed: security scan plus 126 unit tests.
- `make security-check` passed.

No live smoke run was performed in this PR.

## Provider references

Checked current Akamai/Linode API docs while documenting the warning and expected behavior:

- Create Linode API notes that creating a Linode creates account resources and requires region/type inputs: https://techdocs.akamai.com/linode-api/reference/post-linode-instance
- Create Image API documents private image creation from a disk: https://techdocs.akamai.com/linode-api/reference/post-image
- Delete Linode API documents the temporary Linode deletion endpoint: https://techdocs.akamai.com/linode-api/reference/delete-linode-instance
