### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - Require Python 3.12 or newer.
 - Add config-backed execution defaults and `config validate` reports with

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ API, cleans up the temporary instances, and preserves the custom image.
 
 ## Installation
 
-Install the released `v0.1.0` tag directly from GitHub:
+Install the released `v0.2.0` tag directly from GitHub:
 
 ```sh
 python3 -m venv .venv
 . .venv/bin/activate
-python3 -m pip install git+https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0
+python3 -m pip install git+https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.2.0
 linode-image-lab --help
 ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,17 +47,18 @@ first-class outcome.
 ## Linode API Retry Boundary
 
 The Linode API client retries only safe operation classes: non-mutating GET
-preflight reads, polling GET reads, list/read validation calls, managed Linode
-discovery, and cleanup DELETE attempts for already-selected tagged temporary
-Linodes. Retries are bounded, use deterministic backoff without jitter, and
-record public-safe retry event metadata without tokens or provider identifiers.
+preflight reads, polling GET reads, list/read validation calls, and managed
+Linode discovery. Retries are bounded, use deterministic backoff without
+jitter, and record public-safe retry event metadata without tokens or provider
+identifiers.
 For HTTP 429 rate-limit responses, the client honors Linode's documented
 `Retry-After` header when valid, then falls back to `X-RateLimit-Reset` when it
 can be parsed, before using the deterministic backoff.
 
-Create-instance, image-create, shutdown, and other mutation requests remain
-single-attempt so transient failures cannot create duplicate resources or repeat
-unsafe state transitions.
+Create-instance, image-create, shutdown, cleanup DELETE, and other mutation
+requests remain single-attempt so transient failures cannot create duplicate
+resources, repeat unsafe state transitions, or obscure ambiguous delete
+outcomes.
 
 ## Manifest Foundation
 

--- a/examples/config/capture-deploy-smoke.toml
+++ b/examples/config/capture-deploy-smoke.toml
@@ -1,7 +1,7 @@
 schema_version = 1
 
 [defaults]
-region = "us-east"
+region = "us-sea"
 ttl = "2030-01-01T00:00:00Z"
 
 [capture-deploy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "linode-image-lab"
-version = "0.1.0"
+version = "0.2.0"
 description = "Public-safe Linode custom image capture and deploy workflow lab."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/linode_image_lab/__init__.py
+++ b/src/linode_image_lab/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## Summary
- Rename the changelog release notes section to 0.2.0 and bump package-visible version metadata.
- Update README install snippets to use v0.2.0.
- Align cleanup DELETE retry wording with single-attempt behavior and set the smoke config region to us-sea.

## Validation
- make check: passed
- make security-check: passed
- make release-check VERSION=0.2.0: blocked by Makefile guard: `release must run from main after the release PR is merged.`

No live Linode run was performed.