### PR TITLE
Ignore repo-local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.worktrees/
+
 .venv/
 venv/
 .env


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` so repo-local Git worktrees stay untracked.

## Validation
- `make check` passed.
- Confirmed `.gitignore` contains `.worktrees/`.

## Residual risks
- None known.