### PR TITLE
[codex] Document AGENTS validation coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,11 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Validation
 
 - Use `make check` as the canonical validation entrypoint.
-- Use `make security-check` for the public-safety scan.
+- `make check` runs `make security-check` and `make test`.
+- `make smoke` requires `LINODE_TOKEN` and `SMOKE_EXECUTE=1`, creates real
+  Linode resources, and remains manual-only outside canonical PR validation.
+- Release targets and the CI authoritative-source scan sit outside the local
+  blocking `make check` path.
 - Keep validation implemented through the Makefile rather than direct tool
   invocation in normal workflow.
 


### PR DESCRIPTION
## Summary

- Update AGENTS.md to document that make check runs make security-check and make test.
- Clarify that make smoke is manual-only, requires LINODE_TOKEN and SMOKE_EXECUTE=1, and creates real Linode resources.
- Note that release targets and the CI authoritative-source scan remain outside the local blocking make check path.

## Validation

- make check