### PR TITLE
[codex] Add configurable image project tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,16 @@ linode-image-lab config validate --config examples/config/capture-deploy-smoke.t
 Config uses `schema_version = 1` with optional `[defaults]`, `[capture]`,
 `[deploy]`, `[capture-deploy]`, and `[cleanup]` tables. Supported values are
 `region` or `regions`, `ttl`, `source_image`, `image_id`, `type` or
-`instance_type`, `firewall_id`, `authorized_keys`, and
-`authorized_keys_file`, depending on the command. `[deploy].user_data_file`
-can provide deploy-scoped Linode metadata user data. `firewall_id`, authorized
-keys, and user data apply only to deploy instances from `deploy` and
-`capture-deploy`. File inputs are explicit; the tool never discovers keys or
-user data. `[deploy]` authorized keys and user data also apply to the deploy
-phase of `capture-deploy`; `[capture-deploy]` can add command-specific keys.
+`instance_type`, `image_project_tag`, `firewall_id`, `authorized_keys`, and
+`authorized_keys_file`, depending on the command. `[capture].image_project_tag`
+and `[capture-deploy].image_project_tag` set only the captured custom image's
+artifact-facing `project=<value>` tag; temporary Linode lifecycle tags remain
+owned by `linode-image-lab`. `[deploy].user_data_file` can provide
+deploy-scoped Linode metadata user data. `firewall_id`, authorized keys, and
+user data apply only to deploy instances from `deploy` and `capture-deploy`.
+File inputs are explicit; the tool never discovers keys or user data.
+`[deploy]` authorized keys and user data also apply to the deploy phase of
+`capture-deploy`; `[capture-deploy]` can add command-specific keys.
 
 `capture-deploy --execute` accepts multiple regions through repeated
 `--region` flags or `regions = [...]` config. It captures one custom image in
@@ -321,12 +324,20 @@ Modeled resources use rediscoverable tags:
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.
 
+Captured custom images use separate artifact tags. By default the artifact tag
+is `project=linode-image-lab`; `[capture].image_project_tag` or
+`[capture-deploy].image_project_tag` can change the value after `project=`
+without changing temporary Linode cleanup ownership.
+
 ## Manifest Output
 
 Execute manifests use consistent top-level `status`, `steps`, `resources`,
 `validation`, and `cleanup` fields. For single-region `capture-deploy`,
 top-level `resources`, `validation`, and `cleanup` summarize the combined run,
 while nested `capture` and `deploy` blocks show phase-specific details.
+Manifests expose internal cleanup ownership as `lifecycle_tags` and captured
+custom image identity as `artifact_tags`; the legacy top-level `tags` field is
+the lifecycle tag list.
 Multi-region `capture-deploy --execute` emits one combined manifest with
 top-level `status`, `regions`, `capture`, `deploy_results`, and `summary`.
 The nested `capture` value is the single capture manifest, and each

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -179,7 +179,9 @@ LINODE_TOKEN="$LINODE_TOKEN" PYTHONPATH=src python3 -m linode_image_lab.cli \
 ```
 
 Config defaults can replace omitted `--region`, `--source-image`,
-`--image-id`, `--type`, and `--ttl` values. They do not replace `--execute`,
+`--image-id`, `--type`, `--ttl`, and captured image `image_project_tag` values.
+The image project tag affects only captured custom image artifact tags, not
+temporary Linode lifecycle tags. Config defaults do not replace `--execute`,
 preservation flags, run ids, or environment-based token injection.
 Use `linode-image-lab config validate --config PATH --command COMMAND` to
 validate a config file and inspect the effective defaults before a smoke run.

--- a/docs/design.md
+++ b/docs/design.md
@@ -63,9 +63,9 @@ outcomes.
 ## Manifest Foundation
 
 Manifests are plain JSON-compatible dictionaries. They include schema version,
-project, command, mode, regions, timestamps, dry-run status, tags, and planned
-actions. Serialized manifests use stable JSON formatting and redacted provider
-identifiers.
+project, command, mode, regions, timestamps, dry-run status, lifecycle tags,
+artifact tags, and planned actions. Serialized manifests use stable JSON
+formatting and redacted provider identifiers.
 
 M2 capture execution adds `execution_mode`, ordered `steps`, `resources`,
 `capture_source`, `custom_image`, `validation`, and `cleanup` fields. M3 deploy
@@ -104,12 +104,16 @@ Supported config values are intentionally narrow:
 - `source_image` for capture and capture-deploy,
 - `image_id` for deploy,
 - `type` or `instance_type` for capture, deploy, and capture-deploy,
+- `image_project_tag` for captured custom image artifact tags in capture and
+  capture-deploy,
 - `firewall_id` for deploy instances in deploy and capture-deploy,
 - `authorized_keys` and `authorized_keys_file` for deploy instances in deploy
   and capture-deploy,
 - `user_data_file` in `[deploy]` for Linode metadata user data on deploy
   instances.
 
+`image_project_tag` config is a value for the captured image's
+`project=<value>` artifact tag, not a way to configure lifecycle tag keys.
 `--execute`, preservation flags, run id fields, image labels, tokens,
 passwords, private SSH keys, root passwords, inline metadata, and inline
 cloud-init or user-data values are not configurable. Unknown keys and

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,12 +26,13 @@ when they appear in a table that is not used by the selected command.
 
 Supported config values are limited to region defaults, TTL, source image,
 existing custom image id, Linode type, an existing firewall id for deploy
-instances, explicit public SSH authorized keys for deploy instances, and an
-explicit `[deploy].user_data_file` path for deploy metadata user data. Config
-cannot set `--execute`, `--discover`, preservation flags, run ids, image labels,
-tokens, passwords, private SSH keys, root passwords, inline metadata, inline
-cloud-init data, or inline user-data. Raw authorized key contents and raw or
-Base64-encoded user data are not serialized in CLI output.
+instances, explicit public SSH authorized keys for deploy instances, an
+explicit `[deploy].user_data_file` path for deploy metadata user data, and an
+artifact-facing image project tag value for captured custom images. Config
+cannot set `--execute`, `--discover`, preservation flags, run ids, lifecycle tag
+keys, image labels, tokens, passwords, private SSH keys, root passwords, inline
+metadata, inline cloud-init data, or inline user-data. Raw authorized key
+contents and raw or Base64-encoded user data are not serialized in CLI output.
 
 Config loading and validation happen before token lookup. Execute mode and
 `cleanup --discover` still require `LINODE_TOKEN` from the environment or
@@ -98,8 +99,9 @@ attempts.
 
 `capture-deploy --execute` creates resources with `mode=capture-deploy` and a
 component-specific tag: capture resources use `component=capture`, and deploy
-resources use `component=deploy`. The custom image is preserved by default.
-Temporary Linodes are deleted only when all required tags match the current run.
+resources use `component=deploy`. The custom image is preserved by default and
+uses separate artifact tags. Temporary Linodes are deleted only when all
+required lifecycle tags match the current run.
 
 Standalone `cleanup --execute` deletes only expired temporary Linodes with the
 complete managed tag set: `project`, `run_id`, `mode`, `component`, and `ttl`.

--- a/examples/config/capture-deploy-smoke.toml
+++ b/examples/config/capture-deploy-smoke.toml
@@ -7,3 +7,5 @@ ttl = "2030-01-01T00:00:00Z"
 [capture-deploy]
 source_image = "linode/alpine3.23"
 type = "g6-nanode-1"
+# Optional: set the captured custom image artifact tag project=<value>.
+# image_project_tag = "linode-image-lab"

--- a/src/linode_image_lab/capture.py
+++ b/src/linode_image_lab/capture.py
@@ -37,6 +37,7 @@ class CaptureOptions:
     source_image: str | None = None
     instance_type: str | None = None
     image_label: str | None = None
+    image_project_tag: str | None = None
     preserve_source: bool = False
     command: str = "capture"
     mode: str = "capture"
@@ -54,6 +55,7 @@ def capture_plan(
     source_image: str | None = None,
     instance_type: str | None = None,
     image_label: str | None = None,
+    image_project_tag: str | None = None,
     preserve_source: bool = False,
     client: LinodeClientProtocol | None = None,
 ) -> dict[str, Any]:
@@ -65,6 +67,7 @@ def capture_plan(
         source_image=source_image,
         instance_type=instance_type,
         image_label=image_label,
+        image_project_tag=image_project_tag,
         preserve_source=preserve_source,
     )
     if not execute:
@@ -80,6 +83,7 @@ def dry_run_manifest(options: CaptureOptions) -> dict[str, Any]:
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
+        image_project_tag=options.image_project_tag,
         dry_run=True,
         status="planned",
     )
@@ -101,6 +105,7 @@ def execute_capture(
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
+        image_project_tag=options.image_project_tag,
         dry_run=False,
         status="running",
     )
@@ -123,7 +128,8 @@ def execute_capture(
         run_client.preflight()
         finish_step(manifest, "preflight_api_access", client=run_client)
 
-        tags = list(manifest["tags"])
+        lifecycle_tags = list(manifest["lifecycle_tags"])
+        artifact_tags = list(manifest["artifact_tags"])
         region = options.regions[0]
         source_image = required_text(options.source_image)
         instance_type = required_text(options.instance_type)
@@ -142,7 +148,7 @@ def execute_capture(
             source_image=source_image,
             instance_type=instance_type,
             label=source_label,
-            tags=tags,
+            tags=lifecycle_tags,
             root_password=secrets.token_urlsafe(32),
         )
         capture_source["resource_type"] = "linode"
@@ -175,7 +181,7 @@ def execute_capture(
             "source_required_tags_match",
             lambda: validate_required_tags(
                 capture_source,
-                required_tags=tags,
+                required_tags=lifecycle_tags,
                 message="created resource is missing required capture tags",
             ),
         )
@@ -209,7 +215,7 @@ def execute_capture(
         custom_image = run_client.capture_image(
             disk_id=required_int(capture_source.get("disk_id")),
             label=image_label,
-            tags=tags,
+            tags=artifact_tags,
             description=f"linode-image-lab capture run {manifest['run_id']}",
             cloud_init=True,
         )
@@ -231,10 +237,10 @@ def execute_capture(
         record_validation_check(
             manifest["validation"],
             "custom_image_required_tags_match",
-            lambda: validate_required_tags(
+            lambda: validate_expected_tags(
                 custom_image,
-                required_tags=tags,
-                message="created resource is missing required capture tags",
+                expected_tags=artifact_tags,
+                message="created image is missing required artifact tags",
             ),
         )
         manifest["custom_image"] = dict(custom_image)
@@ -250,7 +256,7 @@ def execute_capture(
                 run_client,
                 capture_source=capture_source,
                 preserve_source=options.preserve_source,
-                required_tags=tags,
+                required_tags=lifecycle_tags,
             )
         manifest["status"] = "succeeded"
         return manifest
@@ -265,7 +271,7 @@ def execute_capture(
                     run_client,
                     capture_source=capture_source,
                     preserve_source=options.preserve_source,
-                    required_tags=list(manifest["tags"]),
+                    required_tags=list(manifest["lifecycle_tags"]),
                 )
             except Exception:
                 mark_running_step_failed(manifest, client=run_client)
@@ -394,10 +400,21 @@ def validate_required_tags(resource: dict[str, Any], *, required_tags: list[str]
         raise CaptureError(message)
 
 
+def validate_expected_tags(resource: dict[str, Any], *, expected_tags: list[str], message: str) -> None:
+    if not has_expected_tags(resource, expected_tags):
+        raise CaptureError(message)
+
+
 def has_required_tags(resource: dict[str, Any], required_tags: list[str]) -> bool:
     tags = tags_to_dict(resource.get("tags", []))
     expected = tags_to_dict(required_tags)
     return all(key in tags and tags[key] == expected[key] for key in REQUIRED_TAG_KEYS)
+
+
+def has_expected_tags(resource: dict[str, Any], expected_tags: list[str]) -> bool:
+    tags = tags_to_dict(resource.get("tags", []))
+    expected = tags_to_dict(expected_tags)
+    return all(key in tags and tags[key] == value for key, value in expected.items())
 
 
 def select_capture_disk(disks: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/linode_image_lab/capture_deploy.py
+++ b/src/linode_image_lab/capture_deploy.py
@@ -42,6 +42,7 @@ class CaptureDeployOptions:
     execute: bool = False
     source_image: str | None = None
     instance_type: str | None = None
+    image_project_tag: str | None = None
     firewall_id: int | None = None
     authorized_keys: list[str] | None = None
     user_data: DeployUserData | None = None
@@ -56,6 +57,7 @@ def capture_deploy_plan(
     execute: bool = False,
     source_image: str | None = None,
     instance_type: str | None = None,
+    image_project_tag: str | None = None,
     firewall_id: int | None = None,
     authorized_keys: list[str] | None = None,
     user_data: DeployUserData | None = None,
@@ -69,6 +71,7 @@ def capture_deploy_plan(
         execute=execute,
         source_image=source_image,
         instance_type=instance_type,
+        image_project_tag=image_project_tag,
         firewall_id=firewall_id,
         authorized_keys=authorized_keys,
         user_data=user_data,
@@ -87,6 +90,7 @@ def dry_run_manifest(options: CaptureDeployOptions) -> dict[str, Any]:
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
+        image_project_tag=options.image_project_tag,
         dry_run=True,
         status="planned",
     )
@@ -126,6 +130,7 @@ def execute_multi_region_capture_deploy(
                 execute=True,
                 source_image=required_text(options.source_image),
                 instance_type=required_text(options.instance_type),
+                image_project_tag=options.image_project_tag,
                 preserve_source=False,
                 command="capture-deploy",
                 mode="capture-deploy",
@@ -140,6 +145,7 @@ def execute_multi_region_capture_deploy(
             region=capture_region,
             run_id=manifest["run_id"],
             ttl=manifest["ttl"],
+            image_project_tag=options.image_project_tag,
             exc=exc,
         )
         manifest["status"] = "failed"
@@ -319,6 +325,7 @@ def multi_region_manifest(options: CaptureDeployOptions) -> dict[str, Any]:
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
+        image_project_tag=options.image_project_tag,
         dry_run=False,
         status="running",
     )
@@ -333,6 +340,9 @@ def multi_region_manifest(options: CaptureDeployOptions) -> dict[str, Any]:
         "dry_run": base["dry_run"],
         "execution_mode": "execute",
         "status": base["status"],
+        "tags": base["tags"],
+        "lifecycle_tags": base["lifecycle_tags"],
+        "artifact_tags": base["artifact_tags"],
         "capture": {},
         "deploy_results": {},
         "summary": {
@@ -360,6 +370,7 @@ def execute_single_region_capture_deploy(
         regions=options.regions,
         run_id=options.run_id,
         ttl=options.ttl,
+        image_project_tag=options.image_project_tag,
         dry_run=False,
         status="running",
     )
@@ -386,6 +397,7 @@ def execute_single_region_capture_deploy(
                 execute=True,
                 source_image=required_text(options.source_image),
                 instance_type=required_text(options.instance_type),
+                image_project_tag=options.image_project_tag,
                 preserve_source=False,
                 command="capture-deploy",
                 mode="capture-deploy",
@@ -521,6 +533,7 @@ def failed_capture_manifest(
     region: str,
     run_id: str,
     ttl: str,
+    image_project_tag: str | None = None,
     exc: Exception,
 ) -> dict[str, Any]:
     manifest = create_manifest(
@@ -530,6 +543,7 @@ def failed_capture_manifest(
         regions=[region],
         run_id=run_id,
         ttl=ttl,
+        image_project_tag=image_project_tag,
         dry_run=False,
         status="failed",
     )
@@ -610,6 +624,7 @@ def apply_capture_deploy_shape(manifest: dict[str, Any], *, mutates: bool) -> No
             "component": component,
             "mutates": mutates,
             "tags": tags,
+            "lifecycle_tags": tags,
         }
         for region in manifest["regions"]
         for action, component, tags in (

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -241,6 +241,8 @@ def resolve_config_defaults(args: argparse.Namespace) -> None:
             args.source_image = defaults["source_image"]
         if args.instance_type is None and ("type" in defaults or "instance_type" in defaults):
             args.instance_type = config_instance_type(defaults)
+        if getattr(args, "image_project_tag", None) is None and "image_project_tag" in defaults:
+            args.image_project_tag = defaults["image_project_tag"]
 
     if args.command == "deploy":
         if args.image_id is None and "image_id" in defaults:
@@ -397,6 +399,7 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
             source_image=args.source_image,
             instance_type=args.instance_type,
             image_label=args.image_label,
+            image_project_tag=getattr(args, "image_project_tag", None),
             preserve_source=args.preserve_source,
         )
 
@@ -422,6 +425,7 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
             execute=args.execute,
             source_image=args.source_image,
             instance_type=args.instance_type,
+            image_project_tag=getattr(args, "image_project_tag", None),
             firewall_id=args.firewall_id,
             authorized_keys=args.authorized_keys,
             user_data=args.user_data,

--- a/src/linode_image_lab/config.py
+++ b/src/linode_image_lab/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 import tomllib
 
+from .manifest import normalize_image_project_tag
 from .regions import parse_regions
 from .user_data import DeployUserData, UserDataError, load_user_data_file
 
@@ -27,7 +28,7 @@ ROOT_KEYS = {
 }
 TABLE_FIELDS = {
     "defaults": {"region", "regions", "ttl", "image_id", "type", "instance_type", "firewall_id"},
-    "capture": {"region", "regions", "source_image", "type", "instance_type", "ttl"},
+    "capture": {"region", "regions", "source_image", "type", "instance_type", "ttl", "image_project_tag"},
     "deploy": {
         "region",
         "regions",
@@ -48,6 +49,7 @@ TABLE_FIELDS = {
         "instance_type",
         "firewall_id",
         "ttl",
+        "image_project_tag",
         "authorized_keys",
         "authorized_keys_file",
     },
@@ -56,9 +58,18 @@ TABLE_FIELDS = {
 COMMAND_TABLES = {"capture", "deploy", "capture-deploy", "cleanup"}
 COMMAND_DEFAULT_FIELDS = {
     "plan": ("regions", "ttl"),
-    "capture": ("regions", "ttl", "source_image", "type"),
+    "capture": ("regions", "ttl", "source_image", "type", "image_project_tag"),
     "deploy": ("regions", "ttl", "image_id", "type", "firewall_id", "authorized_keys", "user_data"),
-    "capture-deploy": ("regions", "ttl", "source_image", "type", "firewall_id", "authorized_keys", "user_data"),
+    "capture-deploy": (
+        "regions",
+        "ttl",
+        "source_image",
+        "type",
+        "image_project_tag",
+        "firewall_id",
+        "authorized_keys",
+        "user_data",
+    ),
     "cleanup": ("ttl",),
 }
 CLI_SOURCE_LABELS = {
@@ -208,6 +219,13 @@ def validate_value(table: str, key: str, value: Any) -> None:
             normalize_authorized_key(item, f"config [{table}].authorized_keys[{index}]")
         return
 
+    if key == "image_project_tag":
+        try:
+            normalize_image_project_tag(value, f"config [{table}].image_project_tag")
+        except ValueError as exc:
+            raise ConfigError(str(exc)) from exc
+        return
+
     if key in {"authorized_keys_file", "user_data_file"}:
         if not isinstance(value, str) or not value.strip():
             raise ConfigError(f"config [{table}].{key} must be a non-empty string")
@@ -233,6 +251,10 @@ def normalize_config(config: dict[str, Any], *, base_dir: Path) -> dict[str, Any
             table["authorized_keys_file"] = str(resolve_config_path(table["authorized_keys_file"], base_dir=base_dir))
         if "user_data_file" in table:
             table["user_data_file"] = str(resolve_config_path(table["user_data_file"], base_dir=base_dir))
+        if "image_project_tag" in table:
+            table["image_project_tag"] = normalize_image_project_tag(
+                table["image_project_tag"], f"config [{key}].image_project_tag"
+            )
         normalized[key] = table
     return normalized
 
@@ -510,6 +532,8 @@ def normalize_default_value(field: str, value: Any) -> Any:
         return regions
     if field == "firewall_id":
         return normalize_firewall_id(value, "firewall_id")
+    if field == "image_project_tag":
+        return normalize_image_project_tag(value)
     return value
 
 

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -14,6 +14,7 @@ SCHEMA_VERSION = 1
 VALID_MODES = {"capture", "deploy", "capture-deploy"}
 VALID_COMPONENTS = {"capture", "deploy"}
 REQUIRED_TAG_KEYS = ("project", "run_id", "mode", "component", "ttl")
+RESERVED_TAG_KEYS = frozenset((*REQUIRED_TAG_KEYS, "lifecycle"))
 
 
 def utc_now() -> datetime:
@@ -56,6 +57,24 @@ def generate_tags(*, run_id: str, mode: str, component: str, ttl: str) -> list[s
     ]
 
 
+def normalize_image_project_tag(value: object, label: str = "image_project_tag") -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty tag value")
+    normalized = value.strip()
+    if "=" in normalized:
+        key = normalized.split("=", 1)[0].strip().lower()
+        if key in RESERVED_TAG_KEYS:
+            raise ValueError(f"{label} must not configure internal lifecycle tag key: {key}")
+        raise ValueError(f"{label} must be a tag value, not a key=value tag")
+    return normalized
+
+
+def generate_artifact_tags(*, image_project_tag: str | None = None) -> list[str]:
+    """Generate tags for captured custom image artifacts."""
+    project_tag = normalize_image_project_tag(image_project_tag or PROJECT)
+    return [f"project={project_tag}"]
+
+
 def tags_to_dict(tags: list[str] | dict[str, str]) -> dict[str, str]:
     if isinstance(tags, dict):
         return {str(key): str(value) for key, value in tags.items()}
@@ -81,6 +100,7 @@ def create_manifest(
     component: str | None = None,
     run_id: str | None = None,
     ttl: str | None = None,
+    image_project_tag: str | None = None,
     dry_run: bool = True,
     status: str = "planned",
 ) -> dict[str, Any]:
@@ -94,12 +114,13 @@ def create_manifest(
     manifest_ttl = ttl or default_ttl()
     manifest_component = component or component_for_mode(mode)
     validate_component(manifest_component)
-    tags = generate_tags(
+    lifecycle_tags = generate_tags(
         run_id=manifest_run_id,
         mode=mode,
         component=manifest_component,
         ttl=manifest_ttl,
     )
+    artifact_tags = generate_artifact_tags(image_project_tag=image_project_tag)
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -112,14 +133,17 @@ def create_manifest(
         "ttl": manifest_ttl,
         "dry_run": dry_run,
         "status": status,
-        "tags": tags,
+        "tags": lifecycle_tags,
+        "lifecycle_tags": lifecycle_tags,
+        "artifact_tags": artifact_tags,
         "planned_actions": [
             {
                 "action": command,
                 "region": region,
                 "component": manifest_component,
                 "mutates": False,
-                "tags": tags,
+                "tags": lifecycle_tags,
+                "lifecycle_tags": lifecycle_tags,
             }
             for region in regions
         ],

--- a/tests/unit/test_capture.py
+++ b/tests/unit/test_capture.py
@@ -417,11 +417,35 @@ class CaptureExecutionTests(unittest.TestCase):
             client=client,
         )
 
-        expected_tags = manifest["tags"]
-        self.assertEqual(client.create_tags, expected_tags)
-        self.assertEqual(client.image_tags, expected_tags)
-        self.assertIn("mode=capture", expected_tags)
-        self.assertIn("component=capture", expected_tags)
+        lifecycle_tags = manifest["lifecycle_tags"]
+        artifact_tags = manifest["artifact_tags"]
+        self.assertEqual(manifest["tags"], lifecycle_tags)
+        self.assertEqual(client.create_tags, lifecycle_tags)
+        self.assertEqual(client.image_tags, artifact_tags)
+        self.assertEqual(artifact_tags, ["project=linode-image-lab"])
+        self.assertIn("mode=capture", lifecycle_tags)
+        self.assertIn("component=capture", lifecycle_tags)
+
+    def test_configured_image_project_tag_only_changes_custom_image_tags(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            image_project_tag="customer-image-lab",
+            client=client,
+        )
+
+        self.assertEqual(client.image_tags, ["project=customer-image-lab"])
+        self.assertEqual(manifest["artifact_tags"], ["project=customer-image-lab"])
+        self.assertIn("project=linode-image-lab", client.create_tags)
+        self.assertIn("run_id=run-test", client.create_tags)
+        self.assertNotIn("run_id=run-test", client.image_tags)
+        self.assertEqual(manifest["cleanup"]["status"], "deleted")
 
     def test_preserve_source_skips_success_cleanup_delete(self) -> None:
         client = FakeLinodeClient()

--- a/tests/unit/test_capture_deploy.py
+++ b/tests/unit/test_capture_deploy.py
@@ -787,6 +787,27 @@ class CaptureDeployExecutionTests(unittest.TestCase):
         self.assertIn("mode=capture-deploy", client.deploy_tags)
         self.assertIn("component=deploy", client.deploy_tags)
 
+    def test_configured_image_project_tag_flows_to_captured_image_only(self) -> None:
+        client = FakeLinodeClient()
+
+        manifest = capture_deploy_plan(
+            regions=["us-east"],
+            run_id="run-test",
+            ttl="2030-01-01T00:00:00Z",
+            execute=True,
+            source_image="linode/debian12",
+            instance_type="g6-nanode-1",
+            image_project_tag="customer-image-lab",
+            client=client,
+        )
+
+        self.assertEqual(client.image_tags, ["project=customer-image-lab"])
+        self.assertEqual(manifest["artifact_tags"], ["project=customer-image-lab"])
+        self.assertEqual(manifest["capture"]["custom_image"]["tags"], ["project=customer-image-lab"])
+        self.assertIn("project=linode-image-lab", client.capture_tags)
+        self.assertIn("project=linode-image-lab", client.deploy_tags)
+        self.assertNotIn("run_id=run-test", client.image_tags)
+
     def test_preserve_instance_keeps_deploy_instance_only(self) -> None:
         client = FakeLinodeClient()
 

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -232,6 +232,22 @@ class CleanupSelectionTests(unittest.TestCase):
         self.assertEqual(client.deleted, [])
         self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
 
+    def test_artifact_project_tag_is_not_cleanup_ownership(self) -> None:
+        resource = linode_resource()
+        resource["tags"] = [
+            "project=customer-image-lab",
+            "run_id=run-test",
+            "mode=capture",
+            "component=capture",
+            "ttl=2026-01-01T00:00:00Z",
+        ]
+        client = FakeCleanupClient([resource])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+
     def test_provider_ids_are_redacted_in_serialized_manifest(self) -> None:
         client = FakeCleanupClient([linode_resource(linode_id=987)])
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -707,6 +707,7 @@ class CliTests(unittest.TestCase):
             ttl = "2031-01-01T00:00:00Z"
             source_image = "linode/alpine3.23"
             type = "g6-nanode-1"
+            image_project_tag = "customer-image-lab"
             """
         )
 
@@ -738,6 +739,7 @@ class CliTests(unittest.TestCase):
                 "source_image": "linode/alpine3.23",
                 "ttl": "2031-01-01T00:00:00Z",
                 "type": "g6-nanode-1",
+                "image_project_tag": "customer-image-lab",
             },
         )
         self.assertEqual(
@@ -747,8 +749,76 @@ class CliTests(unittest.TestCase):
                 {"field": "ttl", "source": "[capture].ttl"},
                 {"field": "source_image", "source": "[capture].source_image"},
                 {"field": "type", "source": "[capture].type"},
+                {"field": "image_project_tag", "source": "[capture].image_project_tag"},
             ],
         )
+
+    def test_capture_config_image_project_tag_only_changes_artifact_tags(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture]
+            region = "us-east"
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            image_project_tag = "customer-image-lab"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(["--config", config_path, "capture"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["artifact_tags"], ["project=customer-image-lab"])
+        self.assertIn("project=linode-image-lab", payload["lifecycle_tags"])
+        self.assertIn("run_id=", "\n".join(payload["lifecycle_tags"]))
+        self.assertNotIn("run_id=", "\n".join(payload["artifact_tags"]))
+
+    def test_capture_deploy_config_accepts_image_project_tag(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture-deploy]
+            region = "us-east"
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            image_project_tag = "customer-image-lab"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(["--config", config_path, "capture-deploy"])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["artifact_tags"], ["project=customer-image-lab"])
+        self.assertIn("project=linode-image-lab", payload["component_tags"]["capture"])
+        self.assertIn("project=linode-image-lab", payload["component_tags"]["deploy"])
+
+    def test_config_rejects_image_project_tag_lifecycle_override(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [capture]
+            region = "us-east"
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            image_project_tag = "project=other"
+            """
+        )
+
+        error = StringIO()
+        with redirect_stderr(error), self.assertRaises(SystemExit) as raised:
+            main(["--config", config_path, "capture"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("must not configure internal lifecycle tag key: project", error.getvalue())
 
     def test_config_validate_never_reads_linode_token(self) -> None:
         config_path = self.write_config(

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import json
 import unittest
 
-from linode_image_lab.manifest import create_manifest, generate_tags, serialize_manifest, validate_mode
+from linode_image_lab.manifest import (
+    create_manifest,
+    generate_artifact_tags,
+    generate_tags,
+    serialize_manifest,
+    validate_mode,
+)
 
 
 class ManifestTests(unittest.TestCase):
@@ -42,6 +48,15 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(parsed["project"], "linode-image-lab")
         self.assertEqual(parsed["planned_actions"][0]["region"], "us-east")
         self.assertFalse(parsed["planned_actions"][0]["mutates"])
+        self.assertEqual(parsed["tags"], parsed["lifecycle_tags"])
+        self.assertEqual(parsed["artifact_tags"], ["project=linode-image-lab"])
+
+    def test_generates_configured_artifact_project_tag(self) -> None:
+        self.assertEqual(generate_artifact_tags(image_project_tag="customer-image-lab"), ["project=customer-image-lab"])
+
+    def test_rejects_artifact_project_tag_lifecycle_key_override(self) -> None:
+        with self.assertRaisesRegex(ValueError, "internal lifecycle tag key: project"):
+            generate_artifact_tags(image_project_tag="project=other")
 
     def test_validates_current_modes(self) -> None:
         for mode in ("capture", "deploy", "capture-deploy"):


### PR DESCRIPTION
## Summary

- Add `[capture].image_project_tag` and `[capture-deploy].image_project_tag` config support for the captured custom image artifact-facing `project=<value>` tag.
- Preserve the default artifact tag as `project=linode-image-lab` when the config field is omitted.
- Split manifest tag reporting into immutable `lifecycle_tags` for temporary Linode cleanup ownership and `artifact_tags` for captured custom image identity; the legacy `tags` field remains the lifecycle tag list.

## Lifecycle tag safety

Temporary capture and deploy Linodes still receive the required internal lifecycle tags owned by linode-image-lab: `project`, `run_id`, `mode`, `component`, and `ttl`. Cleanup/discovery continues to require those immutable lifecycle tags and treats artifact project values as non-ownership metadata. The new config field accepts only the project tag value and rejects `key=value` attempts that target lifecycle tag keys such as `project`.

## Validation

- `make check`

## Residual risks / gaps

- No CLI flag was added; this is intentionally config-only to keep the change scoped.
- The field customizes only the captured image artifact project tag, not broader tag schema behavior.

Closes #59