### PR TITLE
docs: align branch naming guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,5 +66,6 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Branches and PRs
 
 - Branch from current `origin/main`.
-- Use focused branch names such as `codex/bootstrap-m1-foundation`.
+- Follow the shared playbook branch naming guidance; use focused,
+  purpose-based names such as `docs/<short-name>` or `feature/<short-name>`.
 - Open PRs against `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,5 +67,5 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Branch from current `origin/main`.
 - Follow the shared playbook branch naming guidance; use focused,
-  purpose-based names such as `docs/<short-name>` or `feature/<short-name>`.
+  purpose-based names such as `docs/<short-name>` or `feat/<short-name>`.
 - Open PRs against `main`.


### PR DESCRIPTION
## Summary
- Replace the repo-local `codex/` branch example with a shared playbook reference.
- Keep Linode Image Lab branch and PR guidance concise and repo-local.

## Validation
- `make check`