### PR TITLE
chore: document repo-local execution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ Repo-local rules take precedence only for repo-specific behavior.
   validation runs, not infrastructure ownership.
 - Keep cleanup and validation first-class in any execution path.
 
+## Local Execution
+
+- Run commands from this repository working directory by default.
+- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Prefer direct `gh ...` commands unless shell behavior is required.
+
 ## Provider Assumptions
 
 - Before changing behavior, docs, tests, or user-facing claims that depend on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Local Execution
 
 - Run commands from this repository working directory by default.
-- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Keep temporary workflow state repo-local, for example `.worktrees/`.
 - Prefer direct `gh ...` commands unless shell behavior is required.
 
 ## Provider Assumptions


### PR DESCRIPTION
Summary
- Add a thin repo-local execution section to AGENTS.md.
- Point normal command execution at the repository working directory.
- Keep temporary workflow state repo-local by default and prefer direct gh commands.

Files changed
- AGENTS.md

Validation
- make check

Residual risks or open questions
- None.
