### PR TITLE
AGENTS-workflow-policy-alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,19 @@ This repository uses the shared `ai-workflow-playbook` as the canonical source
 for general workflow rules. This file is the thin repo-local execution layer.
 Repo-local rules take precedence only for repo-specific behavior.
 
+## Startup And Interaction Mode
+
+- Start with `ai-workflow-playbook/docs/start-here.md` before repository or
+  software work.
+- Before acting, select the interaction mode from
+  `ai-workflow-playbook/docs/repo-readiness.md`: implementation, review/audit,
+  or orchestration/prompt-authoring.
+- Implementation agents make explicit repo changes and carry them through
+  validation, commit, push, and PR delivery.
+- Review/audit agents inspect and report findings without mutating the repo.
+- Orchestration/prompt-authoring agents produce complete, self-contained
+  handoffs or prompts unless explicitly asked to implement.
+
 ## Repo Scope
 
 - This repo contains a public-safe Linode Image Lab scaffold.
@@ -44,7 +57,14 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Prefer direct `git ...` and `gh ...` commands unless shell behavior is required.
+- Use direct command execution for ordinary repo commands such as `git ...`,
+  `gh ...`, `make ...`, `python ...`, and repo-local scripts or tools.
+- Before using `zsh`, `bash`, `sh`, `zsh -lc`, `bash -lc`, `sh -c`, aliases, or
+  equivalent wrapper shells, check whether the command has a direct form and
+  use that direct form when it does.
+- Use shell wrappers only when shell syntax is genuinely required, such as
+  pipelines, redirection, glob expansion, command chaining, scoped environment
+  assignment, compound commands, or shell builtins.
 
 ## Provider Assumptions
 


### PR DESCRIPTION
## Summary

- Add a thin startup and interaction-mode pointer to repo-local `AGENTS.md`.
- Strengthen local command-form guidance to include direct `git`, `gh`, `make`, `python`, repo-local scripts, and wrapper-shell preflight.
- Preserve public-safe, provider-assumption, and manual smoke-validation boundaries.

## Validation

- `make check` passed.

## Source evidence

- `ai-workflow-playbook/docs/start-here.md`
- `ai-workflow-playbook/docs/repo-readiness.md`
- `ai-workflow-playbook/docs/prompts.md`
- `ai-workflow-playbook/docs/review-packet.md`
- `ai-workflow-playbook/docs/tool-adapters/codex.md`
- `ai-workflow-incubator/workflow-patterns/operational-evidence/2026-05-08-workflow-policy-transmission-drift.md`
- `ai-workflow-playbook` PR #149, "Promote canonical workflow output rules"

## Residual risks / follow-ups

- No live Linode smoke validation was run; it remains manual-only and outside canonical PR validation.
