### PR TITLE
Add Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- add Dependabot configuration for GitHub Actions and Python packaging metadata

## Validation
- make check

## Notes
- Hosted security features remain manual/org-admin follow-up.