### PR TITLE
Add --manifest-file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ still come from the environment or approved environment injection.
   expired tagged temporary Linodes and lab-owned custom images only with
   `--execute`.
 - Normal stdout is redacted for public-safe review.
+- `--manifest-file PATH` writes an atomic copy of the same redacted manifest
+  emitted on stdout for `capture`, `deploy`, `capture-deploy`, and `cleanup`;
+  `--manifest-file -` keeps stdout-only behavior.
 
 ## What This Does
 
@@ -364,6 +367,10 @@ custom image identity as `artifact_tags`; the legacy top-level `tags` field is
 kept as a compatibility alias for `lifecycle_tags`. Consumers should treat
 `lifecycle_tags` as the cleanup/validation tag contract and must not treat
 `tags` as captured custom image tags.
+Use `--manifest-file PATH` with `capture`, `deploy`, `capture-deploy`, or
+`cleanup` to persist the exact redacted JSON string emitted on stdout. The
+parent directory must already exist, and partial failure manifests are written
+when execution has a manifest to report.
 Multi-region `capture-deploy --execute` emits one combined manifest with
 top-level `status`, `regions`, `capture`, `deploy_results`, and `summary`.
 The nested `capture` value is the single capture manifest, and each

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
+import tempfile
 import tomllib
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -83,6 +85,13 @@ def add_user_data_arg(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--user-data-file",
         help="Explicit file containing deploy user data to send as Linode metadata.user_data.",
+    )
+
+
+def add_manifest_file_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--manifest-file",
+        help="Optional path for an atomic copy of the redacted JSON manifest. Use '-' for stdout only.",
     )
 
 
@@ -166,6 +175,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_config_arg(capture, dest="command_config")
     add_region_args(capture, required=True)
     capture.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    add_manifest_file_arg(capture)
     capture.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
     capture.add_argument("--type", dest="instance_type", help="Linode type for the temporary capture Linode.")
     capture.add_argument("--image-label", help="Optional label for the captured custom image.")
@@ -180,6 +190,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_config_arg(deploy, dest="command_config")
     add_region_args(deploy, required=True)
     deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    add_manifest_file_arg(deploy)
     deploy.add_argument("--image-id", help="Custom image id for the temporary deploy Linode.")
     deploy.add_argument("--type", dest="instance_type", help="Linode type for the temporary deploy Linode.")
     add_firewall_arg(deploy)
@@ -196,6 +207,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_config_arg(capture_deploy, dest="command_config")
     add_region_args(capture_deploy, required=True)
     capture_deploy.add_argument("--execute", action="store_true", help="Opt into Linode API mutations.")
+    add_manifest_file_arg(capture_deploy)
     capture_deploy.add_argument("--source-image", help="Source image id for the temporary capture Linode.")
     capture_deploy.add_argument(
         "--type",
@@ -217,6 +229,7 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup_mode = cleanup.add_mutually_exclusive_group()
     cleanup_mode.add_argument("--discover", action="store_true", help="Opt into read-only Linode resource discovery.")
     cleanup_mode.add_argument("--execute", action="store_true", help="Opt into Linode API deletion of expired resources.")
+    add_manifest_file_arg(cleanup)
     cleanup.add_argument("--run-id", help="Optional run id filter for cleanup selection.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
@@ -443,10 +456,89 @@ def command_manifest(args: argparse.Namespace) -> dict[str, Any]:
     raise ValueError(f"unsupported command: {args.command}")
 
 
+def manifest_file_path(args: argparse.Namespace) -> Path | None:
+    value = getattr(args, "manifest_file", None)
+    if value in (None, "-"):
+        return None
+    return Path(value)
+
+
+def preflight_manifest_file(args: argparse.Namespace) -> None:
+    path = manifest_file_path(args)
+    if path is None:
+        return
+
+    parent = path.parent if path.parent != Path("") else Path(".")
+    if not parent.exists():
+        raise ValueError(f"--manifest-file parent directory does not exist: {parent}")
+    if not parent.is_dir():
+        raise ValueError(f"--manifest-file parent path is not a directory: {parent}")
+    if path.exists() and path.is_dir():
+        raise ValueError(f"--manifest-file path is a directory: {path}")
+
+    temp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temp_file:
+            temp_path = temp_file.name
+            temp_file.write("")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+    except OSError as exc:
+        raise ValueError(f"--manifest-file path is not writable: {path}") from exc
+    finally:
+        if temp_path is not None:
+            try:
+                Path(temp_path).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def write_manifest_file(args: argparse.Namespace, serialized: str) -> None:
+    path = manifest_file_path(args)
+    if path is None:
+        return
+
+    parent = path.parent if path.parent != Path("") else Path(".")
+    temp_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temp_file:
+            temp_path = temp_file.name
+            temp_file.write(serialized)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            try:
+                Path(temp_path).unlink()
+            except FileNotFoundError:
+                pass
+
+
+def emit_manifest(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
+    serialized = serialize_manifest(manifest)
+    write_manifest_file(args, serialized)
+    sys.stdout.write(serialized)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        preflight_manifest_file(args)
         if args.command == "config":
             manifest = config_validate_manifest(args)
         else:
@@ -454,31 +546,31 @@ def main(argv: list[str] | None = None) -> int:
             manifest = command_manifest(args)
     except CaptureError as exc:
         if exc.manifest is not None:
-            sys.stdout.write(serialize_manifest(exc.manifest))
+            emit_manifest(args, exc.manifest)
             sys.stderr.write("capture --execute failed\n")
             return 1
         parser.error(str(exc))
     except DeployError as exc:
         if exc.manifest is not None:
-            sys.stdout.write(serialize_manifest(exc.manifest))
+            emit_manifest(args, exc.manifest)
             sys.stderr.write("deploy --execute failed\n")
             return 1
         parser.error(str(exc))
     except CaptureDeployError as exc:
         if exc.manifest is not None:
-            sys.stdout.write(serialize_manifest(exc.manifest))
+            emit_manifest(args, exc.manifest)
             sys.stderr.write("capture-deploy --execute failed\n")
             return 1
         parser.error(str(exc))
     except CleanupError as exc:
         if exc.manifest is not None:
-            sys.stdout.write(serialize_manifest(exc.manifest))
+            emit_manifest(args, exc.manifest)
             sys.stderr.write(f"{exc}\n")
             return 1
         parser.error(str(exc))
     except (ConfigError, ValueError) as exc:
         parser.error(str(exc))
-    sys.stdout.write(serialize_manifest(manifest))
+    emit_manifest(args, manifest)
     return 0
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from linode_image_lab.cli import build_parser, main
 from linode_image_lab.config import AUTHORIZED_KEYS_FILE_MAX_BYTES
+from linode_image_lab.linode_api import LinodeTokenError
 from linode_image_lab.user_data import USER_DATA_FILE_MAX_BYTES
 
 PUBLIC_KEY_ONE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA one@example"
@@ -100,6 +101,150 @@ class CliTests(unittest.TestCase):
                 self.assertEqual(payload["command"], command)
                 self.assertEqual(payload["mode"], command)
                 self.assertTrue(payload["dry_run"])
+
+    def test_manifest_file_matches_stdout_for_supported_commands(self) -> None:
+        cases = [
+            [
+                "capture",
+                "--region",
+                "us-east",
+                "--run-id",
+                "run-test",
+                "--ttl",
+                "2030-01-01T00:00:00Z",
+            ],
+            [
+                "deploy",
+                "--region",
+                "us-east",
+                "--run-id",
+                "run-test",
+                "--ttl",
+                "2030-01-01T00:00:00Z",
+                "--image-id",
+                "private/789",
+                "--type",
+                "g6-nanode-1",
+            ],
+            [
+                "capture-deploy",
+                "--region",
+                "us-east",
+                "--run-id",
+                "run-test",
+                "--ttl",
+                "2030-01-01T00:00:00Z",
+                "--source-image",
+                "linode/debian12",
+                "--type",
+                "g6-nanode-1",
+            ],
+            [
+                "cleanup",
+                "--run-id",
+                "run-test",
+                "--ttl",
+                "2030-01-01T00:00:00Z",
+            ],
+        ]
+
+        for argv in cases:
+            with self.subTest(command=argv[0]):
+                directory = tempfile.TemporaryDirectory()
+                self.addCleanup(directory.cleanup)
+                manifest_path = Path(directory.name) / "manifest.json"
+                output = StringIO()
+
+                with redirect_stdout(output):
+                    code = main([*argv, "--manifest-file", str(manifest_path)])
+
+                self.assertEqual(code, 0)
+                self.assertEqual(manifest_path.read_text(encoding="utf-8"), output.getvalue())
+                self.assertEqual(json.loads(output.getvalue())["command"], argv[0])
+
+    def test_manifest_file_dash_uses_stdout_only(self) -> None:
+        output = StringIO()
+
+        with redirect_stdout(output):
+            code = main(["cleanup", "--manifest-file", "-"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(output.getvalue())["command"], "cleanup")
+
+    def test_manifest_file_missing_parent_fails_before_mutation(self) -> None:
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        manifest_path = Path(directory.name) / "missing" / "manifest.json"
+        output = StringIO()
+        error = StringIO()
+
+        with (
+            patch("linode_image_lab.capture.LinodeClient.from_env", side_effect=AssertionError("token lookup")) as token,
+            redirect_stdout(output),
+            redirect_stderr(error),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            main(
+                [
+                    "capture",
+                    "--execute",
+                    "--region",
+                    "us-east",
+                    "--source-image",
+                    "linode/debian12",
+                    "--type",
+                    "g6-nanode-1",
+                    "--manifest-file",
+                    str(manifest_path),
+                ]
+            )
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertEqual(output.getvalue(), "")
+        self.assertIn("--manifest-file parent directory does not exist", error.getvalue())
+        token.assert_not_called()
+
+    def test_manifest_file_persists_partial_failure_manifest(self) -> None:
+        class InvalidTokenClient:
+            def preflight(self) -> None:
+                raise LinodeTokenError("LINODE_TOKEN is invalid, expired, or rejected by the Linode API")
+
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        manifest_path = Path(directory.name) / "failed-manifest.json"
+        output = StringIO()
+        error = StringIO()
+
+        with (
+            patch("linode_image_lab.capture.LinodeClient.from_env", return_value=InvalidTokenClient()),
+            redirect_stdout(output),
+            redirect_stderr(error),
+        ):
+            code = main(
+                [
+                    "capture",
+                    "--execute",
+                    "--region",
+                    "us-east",
+                    "--run-id",
+                    "run-test",
+                    "--ttl",
+                    "2030-01-01T00:00:00Z",
+                    "--source-image",
+                    "linode/debian12",
+                    "--type",
+                    "g6-nanode-1",
+                    "--manifest-file",
+                    str(manifest_path),
+                ]
+            )
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 1)
+        self.assertEqual(manifest_path.read_text(encoding="utf-8"), output.getvalue())
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["steps"][0]["name"], "preflight_api_access")
+        self.assertIn("capture --execute failed", error.getvalue())
 
     def test_legacy_commands_are_not_retained(self) -> None:
         legacy_commands = ("fr" + "eeze", "th" + "aw", "fr" + "eeze-" + "th" + "aw")


### PR DESCRIPTION
## Summary
- Add --manifest-file PATH to capture, deploy, capture-deploy, and cleanup.
- Write the same redacted serialized JSON to the manifest file and stdout, with '-' preserving stdout-only behavior.
- Preflight manifest file destinations before execution and persist partial failure manifests when available.

## Validation
- PYTHONPATH=src python3 -m unittest tests.unit.test_cli
- make check

Linear: CAK-26