### PR TITLE
Add cleanup expiration metadata

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -249,6 +249,14 @@ resources carrying all required managed tags:
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.
 
+Cleanup discovery entries expose machine-readable expiration metadata derived
+from valid `ttl` tags. Expired entries include `expired_at`, the parsed UTC TTL
+timestamp, and `expired_for_seconds`, the integer number of seconds elapsed
+since expiration. Unexpired preserved entries include `expires_in_seconds`, the
+integer number of seconds remaining until expiration. Entries with
+`reason=ttl_parse_failed` omit all derived time fields. `cleanup_candidates` are
+ordered deterministically with the longest-expired candidate first.
+
 Standalone cleanup never deletes untagged resources, broader account resources,
 or images outside the default lab-owned project tag. Those out-of-scope images
 are ignored by standalone cleanup discovery. Malformed TTL values, future TTL

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -113,7 +113,9 @@ def cleanup_plan(
         manifest["resources"] = [resource_summary(resource) for resource in resources]
 
         assessments = assess_cleanup(resources, run_id=run_id, now=now)
-        manifest["cleanup_candidates"] = [item["resource"] for item in assessments if item["action"] == "delete"]
+        manifest["cleanup_candidates"] = sorted_cleanup_candidates(
+            [item["resource"] for item in assessments if item["action"] == "delete"]
+        )
         manifest["cleanup"]["preserved"] = [
             item["resource"] for item in assessments if item["action"] == "preserve"
         ]
@@ -242,11 +244,34 @@ def assess_resource(resource: dict[str, Any], *, run_id: str | None, now: dateti
         summary["reason"] = "ttl_parse_failed"
         return {"action": "preserve", "resource": summary, "provider_id": provider_id}
     if ttl > now:
+        summary["expires_in_seconds"] = seconds_between(now, ttl)
         summary["reason"] = "ttl_not_expired"
         return {"action": "preserve", "resource": summary, "provider_id": provider_id}
 
+    summary["expired_at"] = format_utc_timestamp(ttl)
+    summary["expired_for_seconds"] = seconds_between(ttl, now)
     summary["reason"] = "expired_ttl"
     return {"action": "delete", "resource": summary, "provider_id": provider_id}
+
+
+def sorted_cleanup_candidates(candidates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(candidates, key=cleanup_candidate_sort_key)
+
+
+def cleanup_candidate_sort_key(candidate: dict[str, Any]) -> tuple[object, ...]:
+    return (
+        -int(candidate.get("expired_for_seconds", 0)),
+        str(candidate.get("resource_type", "")),
+        str(candidate.get("linode_id", candidate.get("image_id", ""))),
+    )
+
+
+def seconds_between(start: datetime, end: datetime) -> int:
+    return int((end - start).total_seconds())
+
+
+def format_utc_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
 def resource_summary(resource: dict[str, Any]) -> dict[str, Any]:

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -164,6 +164,52 @@ class CleanupSelectionTests(unittest.TestCase):
         self.assertEqual(client.list_count, 1)
         self.assertEqual(client.image_list_count, 1)
 
+    def test_discover_reports_expiration_metadata_and_orders_longest_expired_first(self) -> None:
+        client = FakeCleanupClient(
+            [
+                linode_resource(linode_id=101, ttl="2026-05-01T00:00:00Z"),
+                linode_resource(linode_id=202, ttl="2026-04-30T23:00:00Z"),
+                linode_resource(linode_id=303, ttl="2026-05-01T01:00:00Z"),
+                linode_resource(linode_id=404, ttl="not-a-timestamp"),
+            ]
+        )
+
+        manifest = cleanup_plan(discover=True, client=client, now=NOW)
+
+        self.assertEqual([item["linode_id"] for item in manifest["cleanup_candidates"]], [202, 101])
+        self.assertEqual(
+            manifest["cleanup_candidates"][0],
+            {
+                "resource_type": "linode",
+                "linode_id": 202,
+                "label": "lil-run-test",
+                "region": "us-east",
+                "status": "running",
+                "tags": [
+                    "project=linode-image-lab",
+                    "run_id=run-test",
+                    "mode=capture-deploy",
+                    "component=capture",
+                    "ttl=2026-04-30T23:00:00Z",
+                ],
+                "expired_at": "2026-04-30T23:00:00Z",
+                "expired_for_seconds": 3600,
+                "reason": "expired_ttl",
+            },
+        )
+        self.assertEqual(manifest["cleanup_candidates"][1]["expired_at"], "2026-05-01T00:00:00Z")
+        self.assertEqual(manifest["cleanup_candidates"][1]["expired_for_seconds"], 0)
+
+        unexpired = next(item for item in manifest["cleanup"]["preserved"] if item["reason"] == "ttl_not_expired")
+        self.assertEqual(unexpired["expires_in_seconds"], 3600)
+        self.assertNotIn("expired_at", unexpired)
+        self.assertNotIn("expired_for_seconds", unexpired)
+
+        malformed = next(item for item in manifest["cleanup"]["preserved"] if item["reason"] == "ttl_parse_failed")
+        self.assertNotIn("expired_at", malformed)
+        self.assertNotIn("expired_for_seconds", malformed)
+        self.assertNotIn("expires_in_seconds", malformed)
+
     def test_execute_deletes_expired_tagged_linode(self) -> None:
         client = FakeCleanupClient([linode_resource(linode_id=456)])
 


### PR DESCRIPTION
## Summary

- Add machine-readable cleanup expiration metadata for valid TTL assessments: `expired_at`, `expired_for_seconds`, and `expires_in_seconds`.
- Sort exposed `cleanup_candidates` deterministically with the longest-expired resources first while leaving cleanup execute deletion behavior unchanged.
- Document the discovery fields in `docs/design.md` and add focused cleanup discovery coverage for expired-now, expired-one-hour-ago, expires-in-one-hour, and malformed TTL entries.

Linear: CAK-27

## Validation

- `make test` passed: 201 tests
- `make check` passed: security-check plus 201 tests