### PR TITLE
Validate explicit run ids

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -257,6 +257,13 @@ integer number of seconds remaining until expiration. Entries with
 `reason=ttl_parse_failed` omit all derived time fields. `cleanup_candidates` are
 ordered deterministically with the longest-expired candidate first.
 
+Explicit `--run-id` values must match
+`^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`: 1 to 64 characters, starting with a
+letter or digit, followed only by letters, digits, dot, underscore, or hyphen.
+The CLI validates supplied run IDs before manifest generation, discovery, or
+execution. Cleanup applies the same validator to discovered `run_id` tags and
+preserves resources whose run ID tag is malformed.
+
 Standalone cleanup never deletes untagged resources, broader account resources,
 or images outside the default lab-owned project tag. Those out-of-scope images
 are ignored by standalone cleanup discovery. Malformed TTL values, future TTL

--- a/src/linode_image_lab/cleanup.py
+++ b/src/linode_image_lab/cleanup.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from .linode_api import LinodeClient, LinodeClientProtocol
-from .manifest import PROJECT, REQUIRED_TAG_KEYS, VALID_COMPONENTS, VALID_MODES, tags_to_dict
+from .manifest import PROJECT, REQUIRED_TAG_KEYS, VALID_COMPONENTS, VALID_MODES, tags_to_dict, validate_run_id
 
 IMAGE_CLEANUP_COMPONENTS = {"capture"}
 
@@ -49,6 +49,8 @@ def is_cleanup_candidate(resource: dict[str, Any], *, now: datetime | None = Non
         return False
     if tags["project"] != PROJECT:
         return False
+    if not has_valid_run_id(tags["run_id"]):
+        return False
     if tags["mode"] not in VALID_MODES:
         return False
     if tags["component"] not in VALID_COMPONENTS:
@@ -81,6 +83,8 @@ def cleanup_plan(
     client: LinodeClientProtocol | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
+    if run_id is not None:
+        validate_run_id(run_id)
     options = CleanupOptions(run_id=run_id, ttl=ttl, discover=discover, execute=execute)
     manifest = base_cleanup_manifest(options)
     if not discover and not execute:
@@ -229,6 +233,9 @@ def assess_resource(resource: dict[str, Any], *, run_id: str | None, now: dateti
     if tags["project"] != PROJECT:
         summary["reason"] = "tag_mismatch"
         return {"action": "preserve", "resource": summary, "provider_id": provider_id}
+    if not has_valid_run_id(tags["run_id"]):
+        summary["reason"] = "invalid_run_id"
+        return {"action": "preserve", "resource": summary, "provider_id": provider_id}
     if run_id is not None and tags["run_id"] != run_id:
         summary["reason"] = "run_id_filter_mismatch"
         return {"action": "preserve", "resource": summary, "provider_id": provider_id}
@@ -272,6 +279,14 @@ def seconds_between(start: datetime, end: datetime) -> int:
 
 def format_utc_timestamp(value: datetime) -> str:
     return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def has_valid_run_id(value: str) -> bool:
+    try:
+        validate_run_id(value)
+    except ValueError:
+        return False
+    return True
 
 
 def resource_summary(resource: dict[str, Any]) -> dict[str, Any]:

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -26,7 +26,7 @@ from .config import (
     normalize_authorized_key,
 )
 from .deploy import DeployError, deploy_plan
-from .manifest import PROJECT, create_manifest, serialize_manifest
+from .manifest import PROJECT, create_manifest, serialize_manifest, validate_run_id
 from .regions import parse_regions
 
 PACKAGE_NAME = "linode-image-lab"
@@ -56,7 +56,7 @@ def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
         required=False,
         help="Linode region id. May be repeated or comma-separated.",
     )
-    parser.add_argument("--run-id", help="Optional run id for deterministic planning.")
+    parser.add_argument("--run-id", type=run_id_value, help="Optional run id for deterministic planning.")
     parser.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
 
@@ -106,6 +106,13 @@ def authorized_key_value(value: str) -> str:
     try:
         return normalize_authorized_key(value, "--authorized-key")
     except ConfigError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def run_id_value(value: str) -> str:
+    try:
+        return validate_run_id(value, "--run-id")
+    except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
@@ -230,7 +237,7 @@ def build_parser() -> argparse.ArgumentParser:
     cleanup_mode.add_argument("--discover", action="store_true", help="Opt into read-only Linode resource discovery.")
     cleanup_mode.add_argument("--execute", action="store_true", help="Opt into Linode API deletion of expired resources.")
     add_manifest_file_arg(cleanup)
-    cleanup.add_argument("--run-id", help="Optional run id filter for cleanup selection.")
+    cleanup.add_argument("--run-id", type=run_id_value, help="Optional run id filter for cleanup selection.")
     cleanup.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
 
     return parser

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -15,6 +16,8 @@ VALID_MODES = {"capture", "deploy", "capture-deploy"}
 VALID_COMPONENTS = {"capture", "deploy"}
 REQUIRED_TAG_KEYS = ("project", "run_id", "mode", "component", "ttl")
 RESERVED_TAG_KEYS = frozenset((*REQUIRED_TAG_KEYS, "lifecycle"))
+RUN_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+RUN_ID_RE = re.compile(RUN_ID_PATTERN)
 
 
 def utc_now() -> datetime:
@@ -44,8 +47,18 @@ def validate_component(component: str) -> str:
     return component
 
 
+def validate_run_id(value: str, label: str = "run_id") -> str:
+    if not isinstance(value, str) or RUN_ID_RE.fullmatch(value) is None:
+        raise ValueError(
+            f"{label} must be 1-64 characters, start with a letter or digit, "
+            "and contain only letters, digits, dot, underscore, or hyphen"
+        )
+    return value
+
+
 def generate_tags(*, run_id: str, mode: str, component: str, ttl: str) -> list[str]:
     """Generate rediscoverable tags for every modeled resource."""
+    validate_run_id(run_id)
     validate_mode(mode)
     validate_component(component)
     return [
@@ -78,6 +91,7 @@ def generate_artifact_tags(
     image_project_tag: str | None = None,
 ) -> list[str]:
     """Generate tags for captured custom image artifacts."""
+    validate_run_id(run_id)
     validate_mode(mode)
     validate_component(component)
     project_tag = normalize_image_project_tag(image_project_tag or PROJECT)
@@ -132,7 +146,7 @@ def create_manifest(
         raise ValueError("at least one non-empty --region is required")
 
     created_at = format_timestamp(utc_now())
-    manifest_run_id = run_id or f"run-{uuid4().hex[:12]}"
+    manifest_run_id = validate_run_id(run_id) if run_id is not None else f"run-{uuid4().hex[:12]}"
     manifest_ttl = ttl or default_ttl()
     manifest_component = component or component_for_mode(mode)
     validate_component(manifest_component)

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -135,6 +135,21 @@ class CleanupSelectionTests(unittest.TestCase):
 
         self.assertEqual([resource["id"] for resource in selected], ["resource-expired"])
 
+    def test_select_cleanup_candidates_rejects_invalid_run_id_tag(self) -> None:
+        resource = linode_resource()
+        resource["id"] = "resource-invalid-run-id"
+        resource["tags"] = [
+            "project=linode-image-lab",
+            "run_id=run,bad",
+            "mode=capture-deploy",
+            "component=capture",
+            "ttl=2026-01-01T00:00:00Z",
+        ]
+
+        selected = select_cleanup_candidates([resource], now=NOW)
+
+        self.assertEqual(selected, [])
+
     def test_plain_cleanup_does_not_discover_or_delete(self) -> None:
         client = FakeCleanupClient([linode_resource()])
 
@@ -413,6 +428,32 @@ class CleanupSelectionTests(unittest.TestCase):
 
         self.assertEqual(client.deleted, [])
         self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "tag_mismatch")
+
+    def test_invalid_discovered_run_id_is_preserved(self) -> None:
+        resource = linode_resource()
+        resource["tags"] = [
+            "project=linode-image-lab",
+            "run_id=run=bad",
+            "mode=capture-deploy",
+            "component=capture",
+            "ttl=2026-01-01T00:00:00Z",
+        ]
+        client = FakeCleanupClient([resource])
+
+        manifest = cleanup_plan(execute=True, client=client, now=NOW)
+
+        self.assertEqual(client.deleted, [])
+        self.assertEqual(manifest["cleanup"]["preserved"][0]["reason"], "invalid_run_id")
+
+    def test_invalid_run_id_filter_fails_before_discovery(self) -> None:
+        client = FakeCleanupClient([linode_resource()])
+
+        with self.assertRaisesRegex(ValueError, "run_id must be 1-64 characters"):
+            cleanup_plan(run_id="run=bad", discover=True, client=client, now=NOW)
+
+        self.assertEqual(client.preflight_count, 0)
+        self.assertEqual(client.list_count, 0)
+        self.assertEqual(client.image_list_count, 0)
 
     def test_artifact_project_tag_is_not_cleanup_ownership(self) -> None:
         resource = linode_resource()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -246,6 +246,28 @@ class CliTests(unittest.TestCase):
         self.assertEqual(payload["steps"][0]["name"], "preflight_api_access")
         self.assertIn("capture --execute failed", error.getvalue())
 
+    def test_invalid_run_id_fails_before_manifest_generation(self) -> None:
+        cases = (
+            ("plan", ["plan", "--region", "us-east"]),
+            ("capture", ["capture", "--region", "us-east"]),
+            ("deploy", ["deploy", "--region", "us-east"]),
+            ("capture-deploy", ["capture-deploy", "--region", "us-east"]),
+            ("cleanup", ["cleanup"]),
+        )
+        for command, args in cases:
+            with self.subTest(command=command):
+                error = StringIO()
+                with (
+                    patch("linode_image_lab.cli.command_manifest", side_effect=AssertionError("manifest generation")),
+                    redirect_stderr(error),
+                    self.assertRaises(SystemExit) as raised,
+                ):
+                    main([*args, "--run-id", "run=private"])
+
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn("--run-id must be 1-64 characters", error.getvalue())
+                self.assertNotIn("run=private", error.getvalue())
+
     def test_legacy_commands_are_not_retained(self) -> None:
         legacy_commands = ("fr" + "eeze", "th" + "aw", "fr" + "eeze-" + "th" + "aw")
         for command in legacy_commands:

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -10,6 +10,7 @@ from linode_image_lab.manifest import (
     lifecycle_tags_from_manifest,
     serialize_manifest,
     validate_mode,
+    validate_run_id,
 )
 
 
@@ -32,6 +33,45 @@ class ManifestTests(unittest.TestCase):
                 "ttl=2030-01-01T00:00:00Z",
             ],
         )
+
+    def test_validates_supported_run_ids(self) -> None:
+        valid_run_ids = (
+            "run-test",
+            "run_test.01",
+            "run-m3-smoke",
+            "A",
+            "a" * 64,
+        )
+
+        for run_id in valid_run_ids:
+            with self.subTest(run_id=run_id):
+                self.assertEqual(validate_run_id(run_id), run_id)
+
+    def test_rejects_invalid_run_ids(self) -> None:
+        invalid_run_ids = (
+            "",
+            " run",
+            "run test",
+            "run,test",
+            "run=test",
+            "-run",
+            "a" * 65,
+            "run\nid",
+        )
+
+        for run_id in invalid_run_ids:
+            with self.subTest(run_id=run_id):
+                with self.assertRaisesRegex(ValueError, "run_id must be 1-64 characters"):
+                    validate_run_id(run_id)
+
+    def test_tag_generation_rejects_invalid_run_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "run_id must be 1-64 characters"):
+            generate_tags(
+                run_id="run,bad",
+                mode="capture",
+                component="capture",
+                ttl="2030-01-01T00:00:00Z",
+            )
 
     def test_creates_serializable_manifest(self) -> None:
         manifest = create_manifest(


### PR DESCRIPTION
## Summary
- Add shared run-id validation with the accepted 1-64 character pattern.
- Apply --run-id validation through argparse before manifest generation, discovery, or execution.
- Reuse the validator for cleanup candidate filtering and document the constraint in docs/design.md.

## Validation
- env PYTHONPATH=src python3 -m unittest tests.unit.test_manifest tests.unit.test_cli tests.unit.test_cleanup
- make check

Linear: CAK-23