### PR TITLE
Add relative TTL input support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Resolve relative TTL inputs such as `"1 day"` at command runtime while
+  preserving absolute UTC TTL values in manifests and cleanup tags.
 - Add `replicate` to dry-run and explicitly execute custom image replication
   while preserving dry-run-first and mutation-gated behavior.
 - Add `firewall-sync` to consume a private trusted network registry and sync

--- a/README.md
+++ b/README.md
@@ -192,8 +192,9 @@ owned by `linode-image-lab`. A non-default image project tag places the
 captured image outside standalone cleanup ownership and discovery.
 `image_project_tag` is config-only and has no CLI override.
 `ttl` may be an absolute ISO-8601 timestamp or a relative duration such as
-`"4 hours"`, `"1 day"`, or `"2 weeks"`. Relative TTLs are resolved at command
-runtime and manifests still emit absolute UTC `ttl` values and `ttl=...` tags.
+`"4 hours"`, `"1 day"`, `"30m"`, `"24h"`, `"7d"`, or `"2w"`. Relative TTLs
+are resolved at command runtime and manifests still emit absolute UTC `ttl`
+values and `ttl=...` tags.
 
 Deploy metadata defaults are field-specific. `firewall_id` is a scalar default
 for deploy instances. Authorized keys are additive: configured

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ artifact-facing `project=<value>` tag; temporary Linode lifecycle tags remain
 owned by `linode-image-lab`. A non-default image project tag places the
 captured image outside standalone cleanup ownership and discovery.
 `image_project_tag` is config-only and has no CLI override.
+`ttl` may be an absolute ISO-8601 timestamp or a relative duration such as
+`"4 hours"`, `"1 day"`, or `"2 weeks"`. Relative TTLs are resolved at command
+runtime and manifests still emit absolute UTC `ttl` values and `ttl=...` tags.
 
 Deploy metadata defaults are field-specific. `firewall_id` is a scalar default
 for deploy instances. Authorized keys are additive: configured
@@ -389,7 +392,7 @@ Modeled resources use rediscoverable tags:
 - `run_id=<unique-id>`
 - `mode=<capture|deploy|capture-deploy>`
 - `component=<capture|deploy>`
-- `ttl=<timestamp>`
+- `ttl=<absolute-utc-timestamp>`
 
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -183,6 +183,9 @@ Config defaults can replace omitted `--region`, `--source-image`,
 The image project tag affects only captured custom image artifact tags, not
 temporary Linode lifecycle tags. Config defaults do not replace `--execute`,
 preservation flags, run ids, or environment-based token injection.
+`ttl` may be an absolute ISO-8601 timestamp or a relative duration such as
+`"1 day"`; relative values are resolved at command runtime and emitted as
+absolute UTC manifest TTLs and `ttl=...` tags.
 Use `linode-image-lab config validate --config PATH --command COMMAND` to
 validate a config file and inspect the effective defaults before a smoke run.
 The report is non-mutating, does not read `LINODE_TOKEN`, and labels precedence
@@ -198,7 +201,7 @@ required tags are present:
 - `run_id=<unique-id>`
 - `mode=<capture|deploy|capture-deploy>`
 - `component=<capture|deploy>`
-- `ttl=<timestamp>`
+- `ttl=<absolute-utc-timestamp>`
 
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -184,8 +184,8 @@ The image project tag affects only captured custom image artifact tags, not
 temporary Linode lifecycle tags. Config defaults do not replace `--execute`,
 preservation flags, run ids, or environment-based token injection.
 `ttl` may be an absolute ISO-8601 timestamp or a relative duration such as
-`"1 day"`; relative values are resolved at command runtime and emitted as
-absolute UTC manifest TTLs and `ttl=...` tags.
+`"1 day"`, `"30m"`, or `"24h"`; relative values are resolved at command
+runtime and emitted as absolute UTC manifest TTLs and `ttl=...` tags.
 Use `linode-image-lab config validate --config PATH --command COMMAND` to
 validate a config file and inspect the effective defaults before a smoke run.
 The report is non-mutating, does not read `LINODE_TOKEN`, and labels precedence

--- a/docs/design.md
+++ b/docs/design.md
@@ -126,6 +126,11 @@ Supported config values are intentionally narrow:
 `image_project_tag` config is a value for the captured image's
 `project=<value>` artifact tag, not a way to configure lifecycle tag keys, and
 has no CLI override.
+`ttl` accepts either an absolute ISO-8601 timestamp or a relative duration such
+as `"4 hours"`, `"1 day"`, or `"2 weeks"`. Relative TTLs are resolved during
+manifest generation against the current command execution time; serialized
+manifests and lifecycle/artifact tags continue to carry absolute UTC TTL
+timestamps.
 `--execute`, preservation flags, run id fields, image labels, tokens,
 passwords, private SSH keys, root passwords, inline metadata, and inline
 cloud-init or user-data values are not configurable. Unknown keys and
@@ -280,7 +285,7 @@ resources carrying all required managed tags:
 - `run_id=...`
 - `mode=...`
 - `component=...`
-- `ttl=...`
+- `ttl=<absolute-utc-timestamp>`
 
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.

--- a/docs/design.md
+++ b/docs/design.md
@@ -127,10 +127,10 @@ Supported config values are intentionally narrow:
 `project=<value>` artifact tag, not a way to configure lifecycle tag keys, and
 has no CLI override.
 `ttl` accepts either an absolute ISO-8601 timestamp or a relative duration such
-as `"4 hours"`, `"1 day"`, or `"2 weeks"`. Relative TTLs are resolved during
-manifest generation against the current command execution time; serialized
-manifests and lifecycle/artifact tags continue to carry absolute UTC TTL
-timestamps.
+as `"4 hours"`, `"1 day"`, `"30m"`, `"24h"`, `"7d"`, or `"2w"`. Relative TTLs
+are resolved during manifest generation against the current command execution
+time; serialized manifests and lifecycle/artifact tags continue to carry
+absolute UTC TTL timestamps.
 `--execute`, preservation flags, run id fields, image labels, tokens,
 passwords, private SSH keys, root passwords, inline metadata, and inline
 cloud-init or user-data values are not configurable. Unknown keys and

--- a/examples/config/capture-deploy-smoke.toml
+++ b/examples/config/capture-deploy-smoke.toml
@@ -2,7 +2,7 @@ schema_version = 1
 
 [defaults]
 region = "us-sea"
-ttl = "1 day"
+ttl = "24h"
 
 [capture-deploy]
 source_image = "linode/alpine3.23"

--- a/examples/config/capture-deploy-smoke.toml
+++ b/examples/config/capture-deploy-smoke.toml
@@ -2,7 +2,7 @@ schema_version = 1
 
 [defaults]
 region = "us-sea"
-ttl = "2030-01-01T00:00:00Z"
+ttl = "1 day"
 
 [capture-deploy]
 source_image = "linode/alpine3.23"

--- a/examples/config/deploy-existing-image.toml
+++ b/examples/config/deploy-existing-image.toml
@@ -2,7 +2,7 @@ schema_version = 1
 
 [defaults]
 region = "us-east"
-ttl = "1 day"
+ttl = "24h"
 
 [deploy]
 image_id = "private/example-custom-image"

--- a/examples/config/deploy-existing-image.toml
+++ b/examples/config/deploy-existing-image.toml
@@ -2,7 +2,7 @@ schema_version = 1
 
 [defaults]
 region = "us-east"
-ttl = "2030-01-01T00:00:00Z"
+ttl = "1 day"
 
 [deploy]
 image_id = "private/example-custom-image"

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -59,7 +59,7 @@ def add_region_args(parser: argparse.ArgumentParser, *, required: bool) -> None:
         help="Linode region id. May be repeated or comma-separated.",
     )
     parser.add_argument("--run-id", type=run_id_value, help="Optional run id for deterministic planning.")
-    parser.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp.")
+    parser.add_argument("--ttl", help="Optional ISO-8601 TTL timestamp or relative duration like '1 day'.")
 
 
 def add_firewall_arg(parser: argparse.ArgumentParser) -> None:

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -20,20 +20,25 @@ RUN_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
 RUN_ID_RE = re.compile(RUN_ID_PATTERN)
 RELATIVE_TTL_RE = re.compile(r"^\s*(?P<amount>[1-9][0-9]*)\s*(?P<unit>[A-Za-z]+)\s*$")
 RELATIVE_TTL_UNITS = {
+    "s": "seconds",
     "second": "seconds",
     "seconds": "seconds",
     "sec": "seconds",
     "secs": "seconds",
+    "m": "minutes",
     "minute": "minutes",
     "minutes": "minutes",
     "min": "minutes",
     "mins": "minutes",
+    "h": "hours",
     "hour": "hours",
     "hours": "hours",
     "hr": "hours",
     "hrs": "hours",
+    "d": "days",
     "day": "days",
     "days": "days",
+    "w": "weeks",
     "week": "weeks",
     "weeks": "weeks",
 }
@@ -67,7 +72,7 @@ def resolve_ttl(value: str | None, *, now: datetime | None = None) -> str:
     if absolute is not None:
         return format_timestamp(absolute)
 
-    raise ValueError("ttl must be an absolute ISO-8601 timestamp or a relative duration like '1 day'")
+    raise ValueError("ttl must be an absolute ISO-8601 timestamp or a relative duration like '1 day' or '24h'")
 
 
 def parse_relative_ttl(value: str) -> timedelta | None:

--- a/src/linode_image_lab/manifest.py
+++ b/src/linode_image_lab/manifest.py
@@ -18,6 +18,25 @@ REQUIRED_TAG_KEYS = ("project", "run_id", "mode", "component", "ttl")
 RESERVED_TAG_KEYS = frozenset((*REQUIRED_TAG_KEYS, "lifecycle"))
 RUN_ID_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
 RUN_ID_RE = re.compile(RUN_ID_PATTERN)
+RELATIVE_TTL_RE = re.compile(r"^\s*(?P<amount>[1-9][0-9]*)\s*(?P<unit>[A-Za-z]+)\s*$")
+RELATIVE_TTL_UNITS = {
+    "second": "seconds",
+    "seconds": "seconds",
+    "sec": "seconds",
+    "secs": "seconds",
+    "minute": "minutes",
+    "minutes": "minutes",
+    "min": "minutes",
+    "mins": "minutes",
+    "hour": "hours",
+    "hours": "hours",
+    "hr": "hours",
+    "hrs": "hours",
+    "day": "days",
+    "days": "days",
+    "week": "weeks",
+    "weeks": "weeks",
+}
 
 
 def utc_now() -> datetime:
@@ -31,6 +50,44 @@ def format_timestamp(value: datetime) -> str:
 def default_ttl(now: datetime | None = None) -> str:
     base = now or utc_now()
     return format_timestamp(base + timedelta(hours=4))
+
+
+def resolve_ttl(value: str | None, *, now: datetime | None = None) -> str:
+    """Resolve absolute or relative TTL input to the UTC tag contract."""
+    base = now or utc_now()
+    if value is None:
+        return default_ttl(base)
+
+    text = value.strip()
+    relative = parse_relative_ttl(text)
+    if relative is not None:
+        return format_timestamp(base + relative)
+
+    absolute = parse_absolute_ttl(text)
+    if absolute is not None:
+        return format_timestamp(absolute)
+
+    raise ValueError("ttl must be an absolute ISO-8601 timestamp or a relative duration like '1 day'")
+
+
+def parse_relative_ttl(value: str) -> timedelta | None:
+    match = RELATIVE_TTL_RE.fullmatch(value)
+    if match is None:
+        return None
+    unit = RELATIVE_TTL_UNITS.get(match.group("unit").lower())
+    if unit is None:
+        return None
+    return timedelta(**{unit: int(match.group("amount"))})
+
+
+def parse_absolute_ttl(value: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def validate_mode(mode: str) -> str:
@@ -147,9 +204,10 @@ def create_manifest(
     if not regions and command != "cleanup":
         raise ValueError("at least one non-empty --region is required")
 
-    created_at = format_timestamp(utc_now())
+    created_now = utc_now()
+    created_at = format_timestamp(created_now)
     manifest_run_id = validate_run_id(run_id) if run_id is not None else f"run-{uuid4().hex[:12]}"
-    manifest_ttl = ttl or default_ttl()
+    manifest_ttl = resolve_ttl(ttl, now=created_now)
     manifest_component = component or component_for_mode(mode)
     validate_component(manifest_component)
     lifecycle_tags = generate_tags(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
@@ -387,6 +388,34 @@ class CliTests(unittest.TestCase):
         self.assertTrue(payload["dry_run"])
         self.assertEqual(payload["regions"], ["us-east"])
         self.assertEqual(payload["ttl"], "2030-01-01T00:00:00Z")
+
+    def test_relative_config_ttl_resolves_at_manifest_runtime(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [defaults]
+            region = "us-east"
+            ttl = "1 day"
+
+            [capture-deploy]
+            source_image = "linode/alpine3.23"
+            type = "g6-nanode-1"
+            """
+        )
+
+        output = StringIO()
+        now = datetime(2026, 5, 20, 12, 30, 45, tzinfo=UTC)
+        with patch("linode_image_lab.manifest.utc_now", return_value=now), redirect_stdout(output):
+            code = main(["capture-deploy", "--config", config_path])
+
+        payload = json.loads(output.getvalue())
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["created_at"], "2026-05-20T12:30:45Z")
+        self.assertEqual(payload["ttl"], "2026-05-21T12:30:45Z")
+        self.assertIn("ttl=2026-05-21T12:30:45Z", payload["lifecycle_tags"])
+        self.assertIn("ttl=2026-05-21T12:30:45Z", payload["component_tags"]["capture"])
+        self.assertIn("ttl=2026-05-21T12:30:45Z", payload["component_tags"]["deploy"])
 
     def test_duplicate_global_and_command_local_config_fails_clearly(self) -> None:
         global_config_path = self.write_config(

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -109,6 +109,11 @@ class ManifestTests(unittest.TestCase):
 
         self.assertEqual(resolve_ttl("1 day", now=now), "2026-05-21T12:30:45Z")
         self.assertEqual(resolve_ttl("90 minutes", now=now), "2026-05-20T14:00:45Z")
+        self.assertEqual(resolve_ttl("30m", now=now), "2026-05-20T13:00:45Z")
+        self.assertEqual(resolve_ttl("24h", now=now), "2026-05-21T12:30:45Z")
+        self.assertEqual(resolve_ttl("7d", now=now), "2026-05-27T12:30:45Z")
+        self.assertEqual(resolve_ttl("2w", now=now), "2026-06-03T12:30:45Z")
+        self.assertEqual(resolve_ttl("45s", now=now), "2026-05-20T12:31:30Z")
 
     def test_normalizes_absolute_ttl_to_utc_timestamp(self) -> None:
         self.assertEqual(
@@ -135,6 +140,8 @@ class ManifestTests(unittest.TestCase):
     def test_rejects_invalid_ttl_input_for_manifest_tags(self) -> None:
         with self.assertRaisesRegex(ValueError, "absolute ISO-8601 timestamp"):
             resolve_ttl("not-a-timestamp")
+        with self.assertRaisesRegex(ValueError, "absolute ISO-8601 timestamp"):
+            resolve_ttl("tomorrow")
 
     def test_legacy_tags_remain_lifecycle_compatibility_alias(self) -> None:
         manifest = {"tags": ["project=linode-image-lab", "run_id=run-test"]}

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import unittest
+from datetime import UTC, datetime
+from unittest.mock import patch
 
 from linode_image_lab.manifest import (
     create_manifest,
     generate_artifact_tags,
     generate_tags,
+    resolve_ttl,
     lifecycle_tags_from_manifest,
     serialize_manifest,
     validate_mode,
@@ -100,6 +103,38 @@ class ManifestTests(unittest.TestCase):
                 "ttl=2030-01-01T00:00:00Z",
             ],
         )
+
+    def test_resolves_relative_ttl_to_utc_timestamp(self) -> None:
+        now = datetime(2026, 5, 20, 12, 30, 45, tzinfo=UTC)
+
+        self.assertEqual(resolve_ttl("1 day", now=now), "2026-05-21T12:30:45Z")
+        self.assertEqual(resolve_ttl("90 minutes", now=now), "2026-05-20T14:00:45Z")
+
+    def test_normalizes_absolute_ttl_to_utc_timestamp(self) -> None:
+        self.assertEqual(
+            resolve_ttl("2030-01-01T02:30:00+02:30"),
+            "2030-01-01T00:00:00Z",
+        )
+
+    def test_relative_ttl_is_resolved_before_tag_generation(self) -> None:
+        now = datetime(2026, 5, 20, 12, 30, 45, tzinfo=UTC)
+        with patch("linode_image_lab.manifest.utc_now", return_value=now):
+            manifest = create_manifest(
+                command="plan",
+                mode="capture",
+                regions=["us-east"],
+                run_id="run-test",
+                ttl="1 day",
+            )
+
+        self.assertEqual(manifest["created_at"], "2026-05-20T12:30:45Z")
+        self.assertEqual(manifest["ttl"], "2026-05-21T12:30:45Z")
+        self.assertIn("ttl=2026-05-21T12:30:45Z", manifest["lifecycle_tags"])
+        self.assertIn("ttl=2026-05-21T12:30:45Z", manifest["artifact_tags"])
+
+    def test_rejects_invalid_ttl_input_for_manifest_tags(self) -> None:
+        with self.assertRaisesRegex(ValueError, "absolute ISO-8601 timestamp"):
+            resolve_ttl("not-a-timestamp")
 
     def test_legacy_tags_remain_lifecycle_compatibility_alias(self) -> None:
         manifest = {"tags": ["project=linode-image-lab", "run_id=run-test"]}


### PR DESCRIPTION
## Summary
- Resolve relative TTL inputs such as `"1 day"` during manifest generation while preserving absolute UTC `ttl` values and `ttl=...` tags.
- Keep cleanup candidate selection unchanged by leaving cleanup parsing and malformed-tag preservation logic untouched.
- Update examples and docs to show static relative TTL config, with focused manifest and CLI/config coverage.

## Validation
- `make check`

## Source-first checks
- Verified GitHub default branch: `main`.
- Verified no open PRs before implementation.
- Reviewed recent TTL/cleanup PRs #81, #83, and #84 for current cleanup behavior and validation expectations.