### PR TITLE
[codex] Scan untracked files in security check

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -68,7 +68,8 @@ execution fails safely because cleanup depends on rediscoverable tags.
 
 ## Public-Safety Scan
 
-`make security-check` scans repository text files for:
+`make security-check` scans tracked text files and untracked non-ignored text
+files for:
 
 - sensitive value assignments,
 - email-like values,

--- a/src/linode_image_lab/validation.py
+++ b/src/linode_image_lab/validation.py
@@ -105,7 +105,7 @@ def iter_scanned_files(root: Path) -> list[Path]:
         return iter_local_files(root)
 
     result = subprocess.run(
-        ["git", "-C", str(root), "ls-files", "-z"],
+        ["git", "-C", str(root), "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
@@ -117,7 +117,9 @@ def iter_scanned_files(root: Path) -> list[Path]:
     for name in result.stdout.decode("utf-8").split("\0"):
         if not name:
             continue
-        files.append(root / Path(name))
+        path = root / Path(name)
+        if path.is_file() and not should_skip_local_path(path.relative_to(root)):
+            files.append(path)
     return files
 
 

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -158,6 +158,32 @@ class ValidationTests(unittest.TestCase):
 
         self.assertEqual(findings, ["README.md: email-like value detected"])
 
+    def test_git_checkout_scans_untracked_non_ignored_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            email_like = "person" + "@" + "example.com"
+            note = root / "NOTES.md"
+            note.write_text(f"contact {email_like}\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, ["NOTES.md: email-like value detected"])
+
+    def test_git_checkout_skips_ignored_untracked_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            subprocess.run(["git", "init"], cwd=root, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            (root / ".gitignore").write_text("local-output/\n", encoding="utf-8")
+            email_like = "person" + "@" + "example.com"
+            ignored = root / "local-output" / "generated.md"
+            ignored.parent.mkdir()
+            ignored.write_text(f"contact {email_like}\n", encoding="utf-8")
+
+            findings = scan_public_safety(root)
+
+        self.assertEqual(findings, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Include untracked non-ignored files in the public-safety scanner.
- Preserve local artifact skips such as `.venv` while using Git ignore rules.
- Document the scanner scope and add unit coverage for untracked and ignored files.

## Validation

- `make check`
