### PR TITLE
Clarify replication docs drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,10 +621,11 @@ custom image identity as `artifact_tags`; the legacy top-level `tags` field is
 kept as a compatibility alias for `lifecycle_tags`. Consumers should treat
 `lifecycle_tags` as the cleanup/validation tag contract and must not treat
 `tags` as captured custom image tags.
-Use `--manifest-file PATH` with `capture`, `deploy`, `capture-deploy`, or
-`cleanup` to persist the exact redacted JSON string emitted on stdout. The
-parent directory must already exist, and partial failure manifests are written
-when execution has a manifest to report.
+Use `--manifest-file PATH` with `capture`, `deploy`, `capture-deploy`,
+`capture-replicate-deploy`, `replicate`, or `cleanup` to persist the exact
+redacted JSON string emitted on stdout. The parent directory must already
+exist, and partial failure manifests are written when execution has a manifest
+to report.
 Multi-region `capture-deploy --execute` emits one combined manifest with
 top-level `status`, `regions`, `capture`, `deploy_results`, and `summary`.
 The nested `capture` value is the single capture manifest, and each

--- a/docs/capture-deploy.md
+++ b/docs/capture-deploy.md
@@ -340,19 +340,20 @@ required tags are present:
 
 - `project=linode-image-lab`
 - `run_id=<unique-id>`
-- `mode=<capture|deploy|capture-deploy>`
-- `component=<capture|deploy>`
+- `mode=<capture|deploy|capture-deploy|capture-replicate-deploy|replicate>`
+- `component=<capture|deploy|replicate>`
 - `ttl=<absolute-utc-timestamp>`
 
 `ttl` is a project-internal cleanup tag used by this tool. Linode does not
 enforce it as a provider-side expiration policy.
 
-Execute-mode cleanup inside capture, deploy, and capture-deploy is narrower
-than standalone cleanup. Capture only attempts to delete the current run's
-temporary capture-source Linode, deploy only attempts to delete the current
-run's temporary deploy Linode, and capture-deploy only attempts to delete those
-two temporary Linodes for the current combined run. In all cases, cleanup
-proceeds only when the resource has all required tags matching the current run.
+Execute-mode cleanup inside capture, deploy, capture-deploy, and
+capture-replicate-deploy is narrower than standalone cleanup. Capture only
+attempts to delete the current run's temporary capture-source Linode, deploy
+only attempts to delete the current run's temporary deploy Linode, and combined
+workflows only attempt to delete temporary Linodes for the current run. In all
+cases, cleanup proceeds only when the resource has all required tags matching
+the current run.
 If tags are missing or do not match, cleanup preserves the resource and records
 `reason=tag_mismatch`.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,8 +9,8 @@ opt-in.
 - `LINODE_TOKEN` may appear as an environment variable name.
 - Secret values must never be committed.
 - The CLI reads `LINODE_TOKEN` for `capture --execute`, `deploy --execute`,
-  `capture-deploy --execute`, `replicate --execute`, `cleanup --discover`, and
-  `cleanup --execute`.
+  `capture-deploy --execute`, `capture-replicate-deploy --execute`,
+  `replicate --execute`, `cleanup --discover`, and `cleanup --execute`.
 - Plain `cleanup` does not read token values or call Linode.
 - Config files cannot provide `LINODE_TOKEN` or any token value. They only fill
   non-secret execution defaults after explicit `--config PATH`.
@@ -47,8 +47,9 @@ selected command table, then `[defaults]`.
 ## Execute Permissions
 
 `capture --execute`, `deploy --execute`, `capture-deploy --execute`,
-`replicate --execute`, `cleanup --discover`, and `cleanup --execute` need a
-personal access token or equivalent OAuth access that can:
+`capture-replicate-deploy --execute`, `replicate --execute`,
+`cleanup --discover`, and `cleanup --execute` need a personal access token or
+equivalent OAuth access that can:
 
 - read the current profile for preflight,
 - read regions, Linode types, images, and configured firewalls for input
@@ -84,22 +85,23 @@ loss prevention system.
 
 ## Mutation Safety
 
-`plan` is dry-run only. `capture`, `deploy`, `capture-deploy`, `replicate`, and
-`cleanup` are dry-run unless `--execute` is provided. Plain `cleanup` is a
-local manifest preview only; it does not read `LINODE_TOKEN` or call Linode.
-`cleanup --discover` is the explicit read-only provider discovery path.
+`plan` is dry-run only. `capture`, `deploy`, `capture-deploy`,
+`capture-replicate-deploy`, `replicate`, and `cleanup` are dry-run unless
+`--execute` is provided. Plain `cleanup` is a local manifest preview only; it
+does not read `LINODE_TOKEN` or call Linode. `cleanup --discover` is the
+explicit read-only provider discovery path.
 
-`capture --execute`, `deploy --execute`, and `capture-deploy --execute` fail
-before mutation if required options or `LINODE_TOKEN` are missing. They perform
-non-mutating token preflight and read-only region, type, and image input
-preflight before creating resources. When a firewall is configured, they also
-preflight the firewall before resource creation and include `firewall_id` in the
-create payload only for deploy instances. Explicit user-data files are loaded,
-checked as non-empty UTF-8 text, Base64 encoded, and included as
-`metadata.user_data` only for deploy instance creation. Partial-failure cleanup
-only targets resources whose required tags exactly match the current run. Tag
-mismatches are represented as preserved resources in manifests, not as deletion
-attempts.
+`capture --execute`, `deploy --execute`, `capture-deploy --execute`, and
+`capture-replicate-deploy --execute` fail before mutation if required options or
+`LINODE_TOKEN` are missing. They perform non-mutating token preflight and
+read-only region, type, and image input preflight before creating resources.
+When a firewall is configured, they also preflight the firewall before resource
+creation and include `firewall_id` in the create payload only for deploy
+instances. Explicit user-data files are loaded, checked as non-empty UTF-8 text,
+Base64 encoded, and included as `metadata.user_data` only for deploy instance
+creation. Partial-failure cleanup only targets resources whose required tags
+exactly match the current run. Tag mismatches are represented as preserved
+resources in manifests, not as deletion attempts.
 
 `replicate --execute` fails before mutation if `--image-id`, one or more
 regions, or `LINODE_TOKEN` are missing. It performs token preflight, reads the


### PR DESCRIPTION
## Summary
- align cleanup tag docs with implemented replication modes/components
- include capture-replicate-deploy in token, permission, and mutation safety docs
- align README manifest-file guidance with CLI support for replicate and capture-replicate-deploy

## Evidence
- CLI help exposes --manifest-file for replicate and capture-replicate-deploy
- implementation constants include capture-replicate-deploy/replicate modes and replicate component
- unit tests cover manifest-file support for these commands

## Validation
- make check