### PR TITLE
Add trusted registry compatibility fixture

### DIFF
--- a/docs/trusted-registry-firewall-sync.md
+++ b/docs/trusted-registry-firewall-sync.md
@@ -7,6 +7,22 @@ target Linode Cloud Firewall rules, and plans one managed inbound allow rule.
 The command is dry-run by default. It mutates the firewall only when
 `--execute` is provided.
 
+## Compatibility Contract
+
+- Consumer: `ctrl-alt-keith/linode-image-lab` `firewall-sync`.
+- Producer: `ctrl-alt-keith/trusted-network-registry`.
+- Artifact: Trusted Network Registry registry JSON.
+- Accepted schema version: registry schema v1, identified by top-level
+  `schema_version: 1`.
+- Compatibility fixture:
+  [`../tests/fixtures/sanitized/trusted-network-registry.v1.example.json`](../tests/fixtures/sanitized/trusted-network-registry.v1.example.json),
+  vendored from the producer's public-safe v1 registry fixture.
+
+The compatibility test feeds the vendored fixture through the trusted registry
+validator and firewall-sync planning path. Incompatible producer artifact
+changes require a new schema/version, and this consumer must explicitly opt in
+before accepting incompatible schema versions.
+
 ## Required Inputs
 
 Non-secret inputs can come from CLI flags or `[firewall-sync]` config:

--- a/tests/fixtures/sanitized/trusted-network-registry.v1.example.json
+++ b/tests/fixtures/sanitized/trusted-network-registry.v1.example.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "registry": {
+    "name": "trusted-network-registry",
+    "generated_at": "2026-05-17T00:00:00Z",
+    "valid_until": "2026-05-17T01:00:00Z",
+    "publisher_version": "0.1.0"
+  },
+  "entries": [
+    {
+      "id": "admin-static-example",
+      "cidr": "198.51.100.0/24",
+      "address_family": "ipv4",
+      "kind": "static",
+      "source_type": "config",
+      "source_ref": "static-admin",
+      "status": "active"
+    },
+    {
+      "id": "admin-static-ipv6-example",
+      "cidr": "2001:db8:100::/64",
+      "address_family": "ipv6",
+      "kind": "static",
+      "source_type": "config",
+      "source_ref": "static-admin-ipv6",
+      "status": "active"
+    },
+    {
+      "id": "meraki-wan1-ipv4",
+      "cidr": "203.0.113.10/32",
+      "address_family": "ipv4",
+      "kind": "discovered",
+      "source_type": "meraki_uplink_addresses",
+      "source_ref": "wan1",
+      "observed_at": "2026-05-17T00:00:00Z",
+      "expires_at": "2026-05-17T01:00:00Z",
+      "status": "active"
+    },
+    {
+      "id": "meraki-wan2-ipv6",
+      "cidr": "2001:db8::10/128",
+      "address_family": "ipv6",
+      "kind": "discovered",
+      "source_type": "meraki_uplink_addresses",
+      "source_ref": "wan2",
+      "observed_at": "2026-05-17T00:00:00Z",
+      "expires_at": "2026-05-17T01:00:00Z",
+      "status": "active"
+    }
+  ],
+  "summary": {
+    "entry_count": 4,
+    "static_count": 2,
+    "discovered_count": 2
+  }
+}

--- a/tests/unit/test_firewall_sync.py
+++ b/tests/unit/test_firewall_sync.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import datetime as dt
 import json
+from pathlib import Path
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
@@ -12,6 +14,11 @@ from linode_image_lab.firewall_sync import (
     FirewallSyncError,
     firewall_sync_plan,
 )
+from linode_image_lab.trusted_registry import validate_registry
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PRODUCER_REGISTRY_FIXTURE = ROOT / "tests/fixtures/sanitized/trusted-network-registry.v1.example.json"
 
 
 class FakeFirewallClient:
@@ -115,6 +122,35 @@ class FirewallSyncTests(unittest.TestCase):
         self.assertEqual(manifest["planned_action"], "add_managed_rule")
         self.assertEqual(manifest["diff"]["additions"]["ipv4"], ["198.51.100.0/24"])
         self.assertEqual(manifest["diff"]["additions"]["ipv6"], ["2001:db8:100::/64"])
+        self.assertEqual(client.updates, [])
+
+    def test_firewall_sync_accepts_vendored_producer_registry_fixture(self) -> None:
+        client = FakeFirewallClient(firewall_rules())
+        payload = json.loads(PRODUCER_REGISTRY_FIXTURE.read_text(encoding="utf-8"))
+
+        def validate_with_fixture_clock(registry_payload: dict[str, object]):
+            return validate_registry(
+                registry_payload,
+                now=dt.datetime(2026, 5, 17, 0, 30, tzinfo=dt.timezone.utc),
+            )
+
+        with (
+            patch("linode_image_lab.firewall_sync.fetch_registry_from_object_storage", return_value=payload),
+            patch("linode_image_lab.firewall_sync.validate_registry", side_effect=validate_with_fixture_clock),
+        ):
+            manifest = firewall_sync_plan(
+                firewall_id=12345,
+                registry_endpoint_url="https://us-east-1.linodeobjects.com",
+                registry_bucket="example-bucket",
+                registry_object_key="registry.json",
+                ports="22",
+                client=client,
+                environ={},
+            )
+
+        self.assertEqual(manifest["registry"]["cidr_count"], 4)
+        self.assertEqual(manifest["diff"]["additions"]["ipv4"], ["198.51.100.0/24", "203.0.113.10/32"])
+        self.assertEqual(manifest["diff"]["additions"]["ipv6"], ["2001:db8:100::/64", "2001:db8::10/128"])
         self.assertEqual(client.updates, [])
 
     def test_execute_requires_explicit_flag(self) -> None:

--- a/tests/unit/test_trusted_registry.py
+++ b/tests/unit/test_trusted_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+from pathlib import Path
 import unittest
 from unittest.mock import patch
 from urllib.error import HTTPError
@@ -14,6 +15,10 @@ from linode_image_lab.trusted_registry import (
     fetch_registry_from_object_storage,
     validate_registry,
 )
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PRODUCER_REGISTRY_FIXTURE = ROOT / "tests/fixtures/sanitized/trusted-network-registry.v1.example.json"
 
 
 class FakeHTTPResponse:
@@ -158,6 +163,28 @@ class TrustedRegistryTests(unittest.TestCase):
 
         self.assertEqual(registry.ipv4_cidrs, ("198.51.100.0/24",))
         self.assertEqual(registry.ipv6_cidrs, ("2001:db8:100::/64",))
+
+    def test_accepts_vendored_producer_registry_v1_fixture(self) -> None:
+        payload = json.loads(PRODUCER_REGISTRY_FIXTURE.read_text(encoding="utf-8"))
+
+        registry = validate_registry(
+            payload,
+            now=dt.datetime(2026, 5, 17, 0, 30, tzinfo=dt.timezone.utc),
+        )
+
+        self.assertEqual(registry.name, "trusted-network-registry")
+        self.assertEqual(registry.ipv4_cidrs, ("198.51.100.0/24", "203.0.113.10/32"))
+        self.assertEqual(registry.ipv6_cidrs, ("2001:db8::10/128", "2001:db8:100::/64"))
+
+    def test_rejects_unsupported_registry_schema_version(self) -> None:
+        payload = json.loads(PRODUCER_REGISTRY_FIXTURE.read_text(encoding="utf-8"))
+        payload["schema_version"] = 2
+
+        with self.assertRaisesRegex(RegistryValidationError, "schema_version is not supported"):
+            validate_registry(
+                payload,
+                now=dt.datetime(2026, 5, 17, 0, 30, tzinfo=dt.timezone.utc),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary
- vendor the trusted-network-registry public-safe registry v1 fixture under sanitized test fixtures
- prove the fixture is accepted by the trusted registry parser and firewall-sync planning path
- pin rejection of unsupported registry schema versions
- document accepted schema version, fixture-based compatibility, and explicit opt-in for incompatible versions

Validation
- make check