### PR TITLE
Clarify firewall-sync architecture boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Repo-local rules take precedence only for repo-specific behavior.
   `capture-deploy --execute`; default behavior remains non-mutating.
 - M5 permits explicit bounded multi-region capture-deploy execution only through
   `capture-deploy --execute`; default behavior remains non-mutating.
+- `firewall-sync --execute` may update only the documented single managed
+  inbound allowlist rule on an existing Cloud Firewall.
 - Do not add additional real Linode mutation behavior until a later milestone
   explicitly asks for it.
 
@@ -41,6 +43,9 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Do not introduce desired-state management concepts.
 - Do not add state files, drift reconciliation, resource graphs, dependency
   planning, or Terraform-like behavior.
+- Do not expand `firewall-sync` into general firewall management, firewall
+  creation or attachment, outbound policy management, continuous sync, or broad
+  firewall reconciliation.
 - Future multi-region support must remain execution fan-out for disposable
   validation runs, not infrastructure ownership.
 - Keep cleanup and validation first-class in any execution path.

--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ for rollback notes, stale-registry behavior, and log-safety cautions.
 - `--execute` enables real Linode API mutations for `capture`, `deploy`,
   `capture-deploy`, `capture-replicate-deploy`, `replicate`, `cleanup`, and
   `firewall-sync`.
+- Existing resources passed to commands remain operator-owned inputs.
+  `firewall-sync` is limited to one labeled inbound allowlist rule on an
+  existing Cloud Firewall, not broader firewall management.
 - Provider behavior assumptions are tracked in
   [docs/provider-assumptions.md](docs/provider-assumptions.md).
 - Scalar config values fill omitted command options; CLI scalar flags override
@@ -510,7 +513,7 @@ for rollback notes, stale-registry behavior, and log-safety cautions.
 ## What This Does Not Do
 
 - SSH, cloud-init, service, or application-level validation.
-- Manage long-lived infrastructure.
+- Manage long-lived infrastructure or broader firewall configuration.
 - General-purpose multi-region orchestration outside bounded
   `capture-deploy --execute` and `capture-replicate-deploy --execute`
   validation runs.

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,6 +16,8 @@ capture/deploy workflows while keeping mutation paths explicit and narrow.
   requested replicas to report available, and deploys from that captured image.
 - Generate and validate a version-controlled region policy artifact that keeps
   provider region facts separate from operator-owned grouping intent.
+- Allow explicit Trusted Network Registry consumption to plan or apply one
+  managed inbound allowlist rule on an existing Cloud Firewall.
 
 ## Non-Goals
 
@@ -37,6 +39,18 @@ Runs remain ephemeral validation workflows with explicit mutation entrypoints,
 provider/API-level validation, tagged temporary resources, and cleanup as a
 first-class outcome.
 
+No infrastructure ownership means the repository does not model an account as
+desired state, create durable infrastructure declarations, reconcile resource
+graphs, or take ownership of operator-managed resources. Commands that accept
+existing resource identifiers treat those resources as operator-owned inputs.
+`firewall-sync` is intentionally narrower than firewall management: it reads a
+private registry, reads one existing Cloud Firewall, and plans or applies only
+the single inbound rule identified by its configured label and fixed managed
+description. It preserves every rule outside that marker, fails closed when the
+marker is ambiguous, and does not create firewalls, attach firewalls, manage
+outbound policy, split allowlists across rules, schedule continuous sync, cache
+fallback CIDRs, or reconcile a broader firewall configuration.
+
 ## Components
 
 - `cli.py` owns command parsing and JSON output.
@@ -50,6 +64,9 @@ first-class outcome.
   replication submission.
 - `manifest.py` owns manifest creation, tag generation, and sanitized
   serialization.
+- `trusted_registry.py` owns Trusted Network Registry fetch and validation.
+- `firewall_sync.py` owns single-managed-rule firewall allowlist planning and
+  explicit execute-mode update.
 - `region_policy.py` owns provider-backed region policy TOML generation and
   validation.
 - `regions.py` owns one-or-many region parsing.

--- a/docs/trusted-registry-firewall-sync.md
+++ b/docs/trusted-registry-firewall-sync.md
@@ -7,6 +7,13 @@ target Linode Cloud Firewall rules, and plans one managed inbound allow rule.
 The command is dry-run by default. It mutates the firewall only when
 `--execute` is provided.
 
+This is not general firewall management. The target firewall is an
+operator-owned existing resource, and the registry controls only the CIDRs for
+one managed inbound allowlist rule. `firewall-sync` does not create or attach
+firewalls, change outbound policy, split allowlists across multiple rules,
+cache fallback CIDRs, run continuously, or reconcile the rest of the firewall
+configuration.
+
 ## Compatibility Contract
 
 - Consumer: `ctrl-alt-keith/linode-image-lab` `firewall-sync`.


### PR DESCRIPTION
## Summary

- Clarify that "no infrastructure ownership" means no desired-state account model, durable declarations, resource graph reconciliation, or ownership of operator-managed resources.
- Document `firewall-sync` as a narrow explicit command that can plan or apply one managed inbound allowlist rule on an existing Cloud Firewall.
- State what `firewall-sync` is not: general firewall management, firewall creation or attachment, outbound policy management, continuous sync, fallback CIDR caching, or broad firewall reconciliation.

## Validation

- `make check`