### PR TITLE
Improve firewall sync config inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,11 @@ defaults, `--firewall-id`, `--authorized-key`, `--authorized-keys-file`, and
 `--user-data-file` can also be previewed. For `capture-replicate-deploy`,
 `--region` previews `deploy_regions`, and `--replication-region`,
 `--replication-group`, and `--region-policy-file` preview policy input
-resolution. Authorized key and user-data output reports safe metadata such as
-count, source, and byte count only.
+resolution. For `firewall-sync`, `--registry-endpoint-url`,
+`--registry-bucket`, `--registry-object-key`, `--registry-region`,
+`--protocol`, `--ports`, and `--managed-label` can also be previewed.
+Authorized key, user-data, provider identifier, and registry location output
+reports safe metadata or redacted values only.
 
 Config is only for execution defaults. It cannot contain `LINODE_TOKEN`, token
 values, passwords, private SSH keys, inline cloud-init data, `execute`,

--- a/src/linode_image_lab/cli.py
+++ b/src/linode_image_lab/cli.py
@@ -124,6 +124,10 @@ def add_user_data_arg(parser: argparse.ArgumentParser) -> None:
 
 def add_registry_firewall_sync_args(parser: argparse.ArgumentParser) -> None:
     add_firewall_arg(parser)
+    add_registry_args(parser)
+
+
+def add_registry_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--registry-endpoint-url", help="Linode Object Storage HTTPS endpoint URL.")
     parser.add_argument("--registry-bucket", help="Object Storage bucket containing the trusted registry.")
     parser.add_argument("--registry-object-key", help="Object Storage object key for the trusted registry JSON.")
@@ -217,6 +221,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_authorized_keys_args(config_validate)
     add_user_data_arg(config_validate)
     add_replication_policy_args(config_validate)
+    add_registry_args(config_validate)
 
     plan = subparsers.add_parser("plan", help="Emit a dry-run manifest preview.")
     add_version_arg(plan, version_text)
@@ -522,6 +527,13 @@ def config_validation_cli_defaults(args: argparse.Namespace) -> dict[str, Any]:
         "type": "--type",
         "firewall_id": "--firewall-id",
         "user_data": "--user-data-file",
+        "registry_endpoint_url": "--registry-endpoint-url",
+        "registry_bucket": "--registry-bucket",
+        "registry_object_key": "--registry-object-key",
+        "registry_region": "--registry-region",
+        "protocol": "--protocol",
+        "ports": "--ports",
+        "managed_label": "--managed-label",
     }
 
     for field, value in candidate_values.items():

--- a/src/linode_image_lab/redaction.py
+++ b/src/linode_image_lab/redaction.py
@@ -23,6 +23,9 @@ PROVIDER_IDENTIFIER_KEYS = {
     "image_id",
     "linode_id",
     "provider_id",
+    "registry_bucket",
+    "registry_endpoint_url",
+    "registry_object_key",
     "resource_id",
     "user_id",
 }

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1146,6 +1146,71 @@ regions = ["us-ghost"]
         self.assertEqual(payload["effective_defaults"]["firewall_id"], "[REDACTED]")
         self.assertIn({"field": "firewall_id", "source": "cli --firewall-id"}, payload["sources"])
 
+    def test_config_validate_previews_firewall_sync_cli_overrides_safely(self) -> None:
+        config_path = self.write_config(
+            """
+            schema_version = 1
+
+            [firewall-sync]
+            firewall_id = 12345
+            registry_endpoint_url = "https://us-east-1.linodeobjects.com"
+            registry_bucket = "config-bucket"
+            registry_object_key = "config-registry.json"
+            registry_region = "us-east-1"
+            protocol = "TCP"
+            ports = "22"
+            managed_label = "config-allowlist"
+            """
+        )
+
+        output = StringIO()
+        with redirect_stdout(output):
+            code = main(
+                [
+                    "config",
+                    "validate",
+                    "--config",
+                    config_path,
+                    "--command",
+                    "firewall-sync",
+                    "--registry-endpoint-url",
+                    "https://us-ord-1.linodeobjects.com",
+                    "--registry-bucket",
+                    "private-bucket",
+                    "--registry-object-key",
+                    "network/registry.json",
+                    "--registry-region",
+                    "us-ord-1",
+                    "--protocol",
+                    "UDP",
+                    "--ports",
+                    "51820",
+                    "--managed-label",
+                    "wireguard-allowlist",
+                ]
+            )
+
+        payload_text = output.getvalue()
+        payload = json.loads(payload_text)
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["target_command"], "firewall-sync")
+        self.assertEqual(payload["effective_defaults"]["registry_endpoint_url"], "[REDACTED]")
+        self.assertEqual(payload["effective_defaults"]["registry_bucket"], "[REDACTED]")
+        self.assertEqual(payload["effective_defaults"]["registry_object_key"], "[REDACTED]")
+        self.assertEqual(payload["effective_defaults"]["registry_region"], "us-ord-1")
+        self.assertEqual(payload["effective_defaults"]["protocol"], "UDP")
+        self.assertEqual(payload["effective_defaults"]["ports"], "51820")
+        self.assertEqual(payload["effective_defaults"]["managed_label"], "wireguard-allowlist")
+        self.assertNotIn("private-bucket", payload_text)
+        self.assertNotIn("network/registry.json", payload_text)
+        self.assertIn({"field": "registry_endpoint_url", "source": "cli --registry-endpoint-url"}, payload["sources"])
+        self.assertIn({"field": "registry_bucket", "source": "cli --registry-bucket"}, payload["sources"])
+        self.assertIn({"field": "registry_object_key", "source": "cli --registry-object-key"}, payload["sources"])
+        self.assertIn({"field": "registry_region", "source": "cli --registry-region"}, payload["sources"])
+        self.assertIn({"field": "protocol", "source": "cli --protocol"}, payload["sources"])
+        self.assertIn({"field": "ports", "source": "cli --ports"}, payload["sources"])
+        self.assertIn({"field": "managed_label", "source": "cli --managed-label"}, payload["sources"])
+
     def test_config_validate_reports_authorized_key_metadata_without_raw_keys(self) -> None:
         keys_path = self.write_file(f"{PUBLIC_KEY_TWO}\n")
         config_path = self.write_config(
@@ -1614,6 +1679,13 @@ regions = ["us-ghost"]
             ("cleanup", ["--authorized-key", PUBLIC_KEY_ONE], "--authorized-key"),
             ("cleanup", ["--authorized-keys-file", keys_path], "--authorized-keys-file"),
             ("cleanup", ["--user-data-file", user_data_path], "--user-data-file"),
+            ("capture", ["--registry-endpoint-url", "https://us-east-1.linodeobjects.com"], "--registry-endpoint-url"),
+            ("capture", ["--registry-bucket", "example-bucket"], "--registry-bucket"),
+            ("capture", ["--registry-object-key", "registry.json"], "--registry-object-key"),
+            ("capture", ["--registry-region", "us-east-1"], "--registry-region"),
+            ("capture", ["--protocol", "TCP"], "--protocol"),
+            ("capture", ["--ports", "22"], "--ports"),
+            ("capture", ["--managed-label", "tnr-allowlist"], "--managed-label"),
         ]
         for command, args, option in cases:
             with self.subTest(command=command, option=option):


### PR DESCRIPTION
## Summary
- let config validate preview firewall-sync registry and managed-rule CLI defaults
- redact registry endpoint, bucket, and object key values from config inspection output
- document the expanded firewall-sync preview surface

## Validation
- make check

## Notes
- no provider mutation behavior changed
- no Linode provider semantics changed